### PR TITLE
Working towards using a utf-8 encoding buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ bower_components/
 node_modules/
 .psci
 .psci_modules/
+yarn-error.log
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ ArrayBuffer bindings for PureScript.
 
 Module documentation is [published on Pursuit](http://pursuit.purescript.org/packages/purescript-arraybuffer).
 
+
+## Important Usage Notes
+
+- Usage of the ArrayBuffer<->String conversion functions requires the import of the NPM package 'text-encoding'.

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "purescript-debug": "^4.0.0",
     "purescript-quickcheck": "^5.0.0",
-    "purescript-partial": "^2.0.0"
+    "purescript-partial": "^2.0.0",
+    "purescript-unicode": "^4.0.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "purescript-maybe": "^4.0.0",
     "purescript-effect": "^2.0.0",
     "purescript-uint": "^4.0.0",
-    "purescript-text-encoding": "^0.0.7"
+    "purescript-text-encoding": "^0.0.8"
   },
   "devDependencies": {
     "purescript-debug": "^4.0.0",

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,8 @@
     "purescript-arraybuffer-types": "^2.0.0",
     "purescript-maybe": "^4.0.0",
     "purescript-effect": "^2.0.0",
-    "purescript-uint": "^4.0.0"
+    "purescript-uint": "^4.0.0",
+    "purescript-text-encoding": "^0.0.7"
   },
   "devDependencies": {
     "purescript-debug": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "purescript-arraybuffer",
+  "version": "7.0.0",
+  "main": "index.js",
+  "repository": "git@github.com:jacereda/purescript-arraybuffer.git",
+  "author": "https://github.com/jacereda",
+  "license": "MIT",
+  "devDependencies": {
+    "text-encoding": "^0.6.4"
+  }
+
+}

--- a/src/Data/ArrayBuffer/ArrayBuffer.js
+++ b/src/Data/ArrayBuffer/ArrayBuffer.js
@@ -25,21 +25,3 @@ exports.fromArray = function(s) {
 exports.fromIntArray = function(s) {
   return (new Uint8Array(s)).buffer;
 };
-
-exports.fromString = function(s) {
-  var buf = new ArrayBuffer(s.length*2);
-  var bufView = new Uint16Array(buf);
-  for (var i=0, strLen=s.length; i<strLen; i++) {
-    bufView[i] = s.charCodeAt(i);
-  }
- return buf;
-};
-
-exports.decodeToStringImpl = function(just, nothing, buffer) {
-  try {
-    return just(String.fromCharCode.apply(null, new Uint16Array(buffer)));
-  }
-  catch (e) {
-    return nothing;
-  }
-};

--- a/src/Data/ArrayBuffer/ArrayBuffer.purs
+++ b/src/Data/ArrayBuffer/ArrayBuffer.purs
@@ -7,10 +7,17 @@ module Data.ArrayBuffer.ArrayBuffer ( create
                                     , decodeToString
                                    ) where
 
-import Effect (Effect)
-import Data.Maybe (Maybe(..))
-import Data.Function.Uncurried (Fn3, runFn3)
+import Data.ArrayBuffer.DataView (whole, buffer)
+import Data.ArrayBuffer.Typed (asUint8Array, dataView)
 import Data.ArrayBuffer.Types (ArrayBuffer, ByteOffset, ByteLength)
+import Data.Either (Either)
+import Data.Function.Uncurried (Fn3, runFn3)
+import Data.TextDecoder (decodeUtf8)
+import Data.TextEncoder (encodeUtf8)
+import Effect (Effect)
+import Effect.Exception (Error)
+import Prelude ((<<<))
+
 
 -- | Create an `ArrayBuffer` with the given capacity.
 foreign import create :: ByteLength -> Effect ArrayBuffer
@@ -30,13 +37,16 @@ foreign import fromArray :: Array Number -> ArrayBuffer
 -- | Convert an array into an `ArrayBuffer` representation.
 foreign import fromIntArray :: Array Int -> ArrayBuffer
 
--- | Convert a string into an `ArrayBuffer` representation.
-foreign import fromString :: String -> ArrayBuffer
+-- | Convert a UTF-8 encoded `ArrayBuffer` into a `String`.
+-- | Serves as a quick utility function for a common use-case. For more use-cases,
+-- | see: [purescript-text-encoding](https://pursuit.purescript.org/packages/purescript-text-encoding/0.0.7)
+-- | Requires the TextDecoder class available. A polyfill can be found in the npm package "text-encoding"
+decodeToString :: ArrayBuffer -> Either Error String
+decodeToString = decodeUtf8 <<< asUint8Array <<< whole
 
-foreign import decodeToStringImpl :: Fn3 (String -> Maybe String) (Maybe String) ArrayBuffer (Maybe String)
-
--- | Convert an ArrayBuffer into a string. Uses fromCharCode and thus does not support full utf-16
--- | Is currently only defined for ArrayBuffers with even numbers of bytes, as it assumes the ArrayBuffer encodes string data.
--- | For more general string-encoding forms of data, use a base64 or other encoding scheme.
-decodeToString :: ArrayBuffer -> Maybe String
-decodeToString = runFn3 decodeToStringImpl Just Nothing
+-- | Convert a  `String` into a UTF-8 encoded `ArrayBuffer`.
+-- | Serves as a quick utility function for a common use-case. For more use-cases,
+-- | see: [purescript-text-encoding](https://pursuit.purescript.org/packages/purescript-text-encoding/0.0.7)
+-- | Requires the TextDecoder class available. A polyfill can be found in the npm package "text-encoding"
+fromString :: String -> ArrayBuffer
+fromString = buffer <<< dataView <<< encodeUtf8

--- a/src/Data/ArrayBuffer/ArrayBuffer.purs
+++ b/src/Data/ArrayBuffer/ArrayBuffer.purs
@@ -39,14 +39,14 @@ foreign import fromIntArray :: Array Int -> ArrayBuffer
 
 -- | Convert a UTF-8 encoded `ArrayBuffer` into a `String`.
 -- | Serves as a quick utility function for a common use-case. For more use-cases,
--- | see: [purescript-text-encoding](https://pursuit.purescript.org/packages/purescript-text-encoding/0.0.7)
+-- | see: [purescript-text-encoding](https://pursuit.purescript.org/packages/purescript-text-encoding/0.0.8)
 -- | Requires the TextDecoder class available. A polyfill can be found in the npm package "text-encoding"
 decodeToString :: ArrayBuffer -> Either Error String
 decodeToString = decodeUtf8 <<< asUint8Array <<< whole
 
 -- | Convert a  `String` into a UTF-8 encoded `ArrayBuffer`.
 -- | Serves as a quick utility function for a common use-case. For more use-cases,
--- | see: [purescript-text-encoding](https://pursuit.purescript.org/packages/purescript-text-encoding/0.0.7)
+-- | see: [purescript-text-encoding](https://pursuit.purescript.org/packages/purescript-text-encoding/0.0.8)
 -- | Requires the TextDecoder class available. A polyfill can be found in the npm package "text-encoding"
 fromString :: String -> ArrayBuffer
 fromString = buffer <<< dataView <<< encodeUtf8

--- a/test/Input.purs
+++ b/test/Input.purs
@@ -1,0 +1,44 @@
+-- Uses code originally found in the purescript-encoding library.
+{-
+   Copyright 2018 Andreas Schacker
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-}
+module Test.Input where
+
+import Data.Char.Unicode          (isPrint)
+import Prelude                    ((<$>), ($), (<<<))
+import Data.Array                 (filter)
+import Data.String.CodeUnits      (fromCharArray, toCharArray)
+import Test.QuickCheck.Arbitrary (class Arbitrary, arbitrary)
+
+
+-- When UTF8-encoding a string, surrogate code points and other non-characters
+-- are simply replaced by the replacement character � (U+FFFD).
+-- This entails that the `encodeUtf8` function is not injective anymore and
+-- thus the desired property `decodeUtf8 <<< encodeUtf8 == id` does not hold
+-- in general.
+--
+-- For well-formed input strings, however, we can expect the property to hold.
+
+-- Use a newtype in order to define an `Arbitrary` instance.
+newtype WellFormedInput = WellFormedInput String
+
+-- The `Arbitrary` instance for `String` currently simply chooses characters
+-- out of the first 65536 unicode code points.
+-- See `charGen` in `purescript-strongcheck`.
+instance arbWellFormedInput :: Arbitrary WellFormedInput where
+  arbitrary = WellFormedInput <<< filterString isPrint <$> arbitrary
+
+filterString :: (Char -> Boolean) -> String -> String
+filterString f s = fromCharArray <<< filter f $ toCharArray s

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -25,6 +25,19 @@ assertEquals expected actual = do
 
 main :: Effect Unit
 main = do
+  assertEquals "釺椱�밸造ə㊡癥闗" (unsafePartial $ fromRight $ AB.decodeToString $ AB.fromString "釺椱�밸造ə㊡癥闗")
+
+  quickCheck
+    \(s) ->
+        let
+          result = (unsafePartial $ fromRight $ AB.decodeToString $ AB.fromString s)
+        in
+          s == result
+          <?> "Isormorphic arraybuffer conversion with string failed for input\n"
+          <> s
+          <> " which, after the round trip, result in\n"
+          <> result
+
   ab4 <- AB.create 4
   ab8 <- AB.create 8
   assertEquals 4 $ AB.byteLength ab4
@@ -50,19 +63,6 @@ main = do
   assertEffEquals (Just 2.0) $ TA.at fourElementInt8Array 1
   assertEffEquals Nothing $ TA.at fourElementInt8Array 4
   assertEffEquals Nothing $ TA.at fourElementInt8Array (-1)
-
-  assertEquals "釺椱�밸造ə㊡癥闗" (unsafePartial $ fromRight $ AB.decodeToString $ AB.fromString "釺椱�밸造ə㊡癥闗")
-
-  quickCheck
-    \(s) ->
-        let
-          result = (unsafePartial $ fromRight $ AB.decodeToString $ AB.fromString s)
-        in
-          s == result
-          <?> "Isormorphic arraybuffer conversion with string failed for input\n"
-          <> s
-          <> " which, after the round trip, result in\n"
-          <> result
 
   assertEquals [1.0, 2.0, 3.0] $ TA.toArray <<< TA.asInt8Array <<< DV.whole $ AB.fromArray [1.0, 2.0, 3.0]
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -51,6 +51,8 @@ main = do
   assertEffEquals Nothing $ TA.at fourElementInt8Array 4
   assertEffEquals Nothing $ TA.at fourElementInt8Array (-1)
 
+  assertEquals "釺椱�밸造ə㊡癥闗" (unsafePartial $ fromRight $ AB.decodeToString $ AB.fromString "釺椱�밸造ə㊡癥闗")
+
   quickCheck
     \(s) ->
         let

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -11,6 +11,7 @@ import Data.Maybe (Maybe(..), isNothing)
 import Data.UInt (fromInt, pow)
 import Partial.Unsafe (unsafePartial)
 import Test.QuickCheck (quickCheck', (<?>), quickCheck)
+import Test.Input
 
 assertEffEquals :: forall a. Eq a => Show a => a -> Effect a -> Effect Unit
 assertEffEquals expectedValue computation = do
@@ -28,7 +29,7 @@ main = do
   assertEquals "釺椱�밸造ə㊡癥闗" (unsafePartial $ fromRight $ AB.decodeToString $ AB.fromString "釺椱�밸造ə㊡癥闗")
 
   quickCheck
-    \(s) ->
+    \(WellFormedInput s) ->
         let
           result = (unsafePartial $ fromRight $ AB.decodeToString $ AB.fromString s)
         in


### PR DESCRIPTION
This would eliminate the partial functions problem with using utf-16 at the encoding level of the buffer.

The problem I currently face now is the tests fail on items like this:

```
Error: Test 6 (seed 1850340696) failed: 
Isormorphic arraybuffer conversion with string failed for input
釺椱�밸造ə㊡癥闗 which, after the round trip, result in
釺椱�밸造ə㊡癥闗
```

So far I'm rather baffled.

My current suspicion is that the generated original string has perhaps invalid code units or code points or something, because of the way quick-check generates the Chars that get concatted.

Or maybe I'm missing something, but -visually- these represent the same text.

Obviously they aren't perfectly identical though, as they are failing equality checks. (or maybe I'm missing something about string equality comparisons in the node environment altogether)