### PR TITLE
Bump purescript-text-encoding version dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "purescript-maybe": "^4.0.0",
     "purescript-effect": "^2.0.0",
     "purescript-uint": "^4.0.0",
-    "purescript-text-encoding": "^0.0.8"
+    "purescript-text-encoding": "^0.0.9"
   },
   "devDependencies": {
     "purescript-debug": "^4.0.0",


### PR DESCRIPTION
The main reason for this is that it will improve user problem solving ability when running into issues with the transient text-encoding dependency in node environments.

With this version users should now encounter a message like this: 

```
You appear to be trying to use the purescript-text-encoding in a node based environment without having the text-encoding polyfill available in your node_modules.
This can be easily resolved by adding it to your package.json dependencies. if this is not sufficient, please feel free to contact the maintainer of this library via its github here:
https://github.com/AlexaDeWit/purescript-text-encoding
/home/alexa/Workspace/purescript-encoding/output/Data.TextDecoder/foreign.js:15
    throw new Error("Text encoding polyfill library could not be imported.");
```

When lacking the appropriate polyfill.