### PR TITLE
no need to distinguish DataView class and BinaryValue class

### DIFF
--- a/src/Data/ArrayBuffer/DataView.purs
+++ b/src/Data/ArrayBuffer/DataView.purs
@@ -7,8 +7,6 @@ module Data.ArrayBuffer.DataView
        , buffer
        , byteLength
        , byteOffset
-       , class DataView
-       , class ShowArrayViewType
        , get
        , getBE
        , getFloat32be
@@ -48,8 +46,8 @@ module Data.ArrayBuffer.DataView
        , whole
        ) where
 
-import Data.ArrayBuffer.Types (ArrayBuffer, ByteLength, ByteOffset, DataView, Float32, Float64, Int16, Int32, Int8, Uint16, Uint32, Uint8, Uint8Clamped, kind ArrayViewType)
-import Data.ArrayBuffer.ValueMapping (class BinaryValue, class BytesPerValue)
+import Data.ArrayBuffer.Types (ArrayBuffer, ByteLength, ByteOffset, DataView, Float32, Float64, Int16, Int32, Int8, Uint16, Uint32, Uint8, kind ArrayViewType)
+import Data.ArrayBuffer.ValueMapping (class BinaryValue, class BytesPerValue, class ShowArrayViewType)
 import Data.Float32 (Float32) as F
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
@@ -96,29 +94,6 @@ instance eqEndian :: Eq Endian where
   eq BE BE = true
   eq _ _ = false
 
-class BinaryValue a t <= DataView (a :: ArrayViewType) t | a -> t
-
-instance dataViewUint8Clamped :: DataView Uint8Clamped UInt
-instance dataViewUint32 :: DataView Uint32 UInt
-instance dataViewUint16 :: DataView Uint16 UInt
-instance dataViewUint8 :: DataView Uint8 UInt
-instance dataViewInt32 :: DataView Int32 Int
-instance dataViewInt16 :: DataView Int16 Int
-instance dataViewInt8 :: DataView Int8 Int
-instance dataViewFloat32 :: DataView Float32 F.Float32
-instance dataViewFloat64 :: DataView Float64 Number
-
-
-class ShowArrayViewType (a :: ArrayViewType) (name :: Symbol) | a -> name
-instance showArrayViewTypeUint8Clamped :: ShowArrayViewType Uint8Clamped "Uint8Clamped"
-instance showArrayViewTypeViewUint32 :: ShowArrayViewType Uint32 "Uint32"
-instance showArrayViewTypeViewUint16 :: ShowArrayViewType Uint16 "Uint16"
-instance showArrayViewTypeViewUint8 :: ShowArrayViewType Uint8 "Uint8"
-instance showArrayViewTypeViewInt32 :: ShowArrayViewType Int32 "Int32"
-instance showArrayViewTypeViewInt16 :: ShowArrayViewType Int16 "Int16"
-instance showArrayViewTypeViewInt8 :: ShowArrayViewType Int8 "Int8"
-instance showArrayViewTypeViewFloat32 :: ShowArrayViewType Float32 "Float32"
-instance showArrayViewTypeViewFloat64 :: ShowArrayViewType Float64 "Float64"
 
 getter :: forall t.
           { functionName :: String
@@ -141,7 +116,7 @@ foreign import getterImpl :: forall t
 
 
 get :: forall a name t b
-     . DataView a t
+     . BinaryValue a t
     => BytesPerValue a b
     => ShowArrayViewType a name
     => IsSymbol name
@@ -157,7 +132,7 @@ get endian prx =
             }
 
 getBE :: forall a name t b
-       . DataView a t
+       . BinaryValue a t
       => BytesPerValue a b
       => ShowArrayViewType a name
       => IsSymbol name
@@ -166,7 +141,7 @@ getBE :: forall a name t b
 getBE = get BE
 
 getLE :: forall a name t b
-       . DataView a t
+       . BinaryValue a t
       => BytesPerValue a b
       => ShowArrayViewType a name
       => IsSymbol name
@@ -188,7 +163,7 @@ foreign import setterImpl :: forall t
 
 
 set :: forall a name t b
-     . DataView a t
+     . BinaryValue a t
     => BytesPerValue a b
     => ShowArrayViewType a name
     => IsSymbol name
@@ -262,7 +237,7 @@ getFloat64le = getLE (AProxy :: AProxy Float64)
 
 -- | Store big-endian value at a certain index in a `DataView`.
 setBE :: forall a name t b
-       . DataView a t
+       . BinaryValue a t
       => BytesPerValue a b
       => ShowArrayViewType a name
       => IsSymbol name
@@ -272,7 +247,7 @@ setBE = set BE
 
 -- | Store little-endian value at a certain index in a `DataView`.
 setLE :: forall a name t b
-       . DataView a t
+       . BinaryValue a t
       => BytesPerValue a b
       => ShowArrayViewType a name
       => IsSymbol name

--- a/src/Data/ArrayBuffer/DataView/Gen.purs
+++ b/src/Data/ArrayBuffer/DataView/Gen.purs
@@ -6,9 +6,9 @@ import Control.Monad.Gen (suchThat)
 import Control.Monad.Gen.Class (class MonadGen, chooseInt)
 import Control.Monad.Rec.Class (class MonadRec)
 import Data.ArrayBuffer.ArrayBuffer.Gen (genArrayBuffer)
-import Data.ArrayBuffer.DataView (whole, byteLength, class DataView)
+import Data.ArrayBuffer.DataView (whole, byteLength)
 import Data.ArrayBuffer.Types (DataView, ByteOffset, kind ArrayViewType)
-import Data.ArrayBuffer.ValueMapping (class BytesPerValue)
+import Data.ArrayBuffer.ValueMapping (class BytesPerValue, class BinaryValue)
 import Data.Maybe (Maybe(Just))
 import Data.Typelevel.Num (class Nat, toInt')
 import Data.Unfoldable (replicateA)
@@ -34,7 +34,7 @@ genWithOffsetAndValue :: forall m n a b t
                       => MonadRec m
                       => Nat n
                       => BytesPerValue a b
-                      => DataView a t
+                      => BinaryValue a t
                       => Nat b
                       => m DataView -- ^ Assumes generated length is at least the minimum length of one value
                       -> m t

--- a/src/Data/ArrayBuffer/ValueMapping.purs
+++ b/src/Data/ArrayBuffer/ValueMapping.purs
@@ -35,3 +35,16 @@ instance binaryValueInt16 :: BinaryValue Int16 Int
 instance binaryValueInt8 :: BinaryValue Int8 Int
 instance binaryValueFloat32 :: BinaryValue Float32 F.Float32
 instance binaryValueFloat64 :: BinaryValue Float64 Number
+
+
+
+class ShowArrayViewType (a :: ArrayViewType) (name :: Symbol) | a -> name
+instance showArrayViewTypeUint8Clamped :: ShowArrayViewType Uint8Clamped "Uint8Clamped"
+instance showArrayViewTypeViewUint32 :: ShowArrayViewType Uint32 "Uint32"
+instance showArrayViewTypeViewUint16 :: ShowArrayViewType Uint16 "Uint16"
+instance showArrayViewTypeViewUint8 :: ShowArrayViewType Uint8 "Uint8"
+instance showArrayViewTypeViewInt32 :: ShowArrayViewType Int32 "Int32"
+instance showArrayViewTypeViewInt16 :: ShowArrayViewType Int16 "Int16"
+instance showArrayViewTypeViewInt8 :: ShowArrayViewType Int8 "Int8"
+instance showArrayViewTypeViewFloat32 :: ShowArrayViewType Float32 "Float32"
+instance showArrayViewTypeViewFloat64 :: ShowArrayViewType Float64 "Float64"

--- a/test/Properties/DataView.purs
+++ b/test/Properties/DataView.purs
@@ -7,7 +7,7 @@ import Data.ArrayBuffer.DataView as DV
 import Data.ArrayBuffer.DataView.Gen (genDataView, genWithOffsetAndValue, WithOffsetAndValue(..))
 import Data.ArrayBuffer.Typed.Gen (genFloat32, genFloat64, genInt16, genInt32, genInt8, genUint16, genUint32, genUint8)
 import Data.ArrayBuffer.Types (Float32, Float64, Int16, Int32, Int8, Uint16, Uint32, Uint8)
-import Data.ArrayBuffer.ValueMapping (class BytesPerValue)
+import Data.ArrayBuffer.ValueMapping (class BytesPerValue, class ShowArrayViewType, class BinaryValue)
 import Data.Maybe (Maybe(..))
 import Data.Typelevel.Num (class Nat, D1, D2, D4, D8)
 import Data.UInt (UInt)
@@ -37,10 +37,10 @@ type TestableViewF a name b n t q =
   => Ord t
   => Semiring t
   => BytesPerValue a b
-  => DV.ShowArrayViewType a name
+  => BinaryValue a t
+  => ShowArrayViewType a name
   => IsSymbol name
   => Nat b
-  => DV.DataView a t
   => WithOffsetAndValue n a t
   -> q
 


### PR DESCRIPTION
DataViews should use the exact same value mapping as typed arrays, imho. So therefore, there shouldn't be a reason to distinguish them from each other.