### PR TITLE
Execute the IE TypedArray polyfill directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Notable changes to this project are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+@jamesdbrock Bugfix for purs bundle 0.14.4. https://github.com/purescript-contrib/purescript-arraybuffer/issues/34
+
 ## v11.0.0
 
 Jorge Acereda has graciously donated this package to __purescript-contrib__.

--- a/src/Data/ArrayBuffer/Typed.js
+++ b/src/Data/ArrayBuffer/Typed.js
@@ -1,23 +1,26 @@
 "use strict";
 
-
-
-// Lightweight polyfill for ie - see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Methods_Polyfill
-function polyFill () {
-    var typedArrayTypes =
+// Lightweight polyfill for IE
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Methods_Polyfill
+//
+// Can we trust that this FFI code gets called exactly once? I think so, but
+// I can't find a reference for that.
+{
+    // var is not block scoped, but there is no way to scope this block inside
+    // a function in such a way that the function will not be dead-code-eliminated.
+    // https://github.com/purescript-contrib/purescript-arraybuffer/issues/34
+    var _typedArrayTypes =
         [ Int8Array, Uint8Array, Uint8ClampedArray, Int16Array
         , Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array
         ];
 
-    for (var k in typedArrayTypes) {
+    for (var k in _typedArrayTypes) {
         for (var v in Array.prototype) {
-            if (Array.prototype.hasOwnProperty(v) && !typedArrayTypes[k].prototype.hasOwnProperty(v))
-                typedArrayTypes[k].prototype[v] = Array.prototype[v];
+            if (Array.prototype.hasOwnProperty(v) && !_typedArrayTypes[k].prototype.hasOwnProperty(v))
+                _typedArrayTypes[k].prototype[v] = Array.prototype[v];
         }
     }
 };
-
-polyFill();
 
 // module Data.ArrayBuffer.Typed
 

--- a/src/Data/ArrayBuffer/Typed.purs
+++ b/src/Data/ArrayBuffer/Typed.purs
@@ -401,3 +401,4 @@ compare a b = Prelude.compare <$> toArray a <*> toArray b
 -- | Equality test for typed arrays.
 eq :: forall a t. TypedArray a t => Eq t => ArrayView a -> ArrayView a -> Effect Boolean
 eq a b = Prelude.eq <$> toArray a <*> toArray b
+


### PR DESCRIPTION
Execute the IE TypedArray polyfill directly because the polyFill() function gets dead-code-eliminated by `purs
bundle` in purs 0.14.4.

This library will now pass [this test](https://github.com/purescript-contrib/purescript-arraybuffer/issues/34#issuecomment-915289229) for purs 0.14.4, and still passes for 0.14.3.

Resolves #34
