### PR TITLE
Delete the TypedArray polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to this project are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+@jamesdbrock Delete the `TypedArray` polyfill which was preventing this
+library from working with `purs bundle` v0.14.4.
+https://github.com/purescript-contrib/purescript-arraybuffer/issues/34
+
 ## v11.0.0
 
 Jorge Acereda has graciously donated this package to __purescript-contrib__.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ You can contribute to `arraybuffer` in several ways:
 
 3. If you have written a library, tutorial, guide, or other resource based on this package, please share it on the [PureScript Discourse](https://discourse.purescript.org)! Writing libraries and learning resources are a great way to help this library succeed.
 
+## Usage
+
+### Polyfill
+
+This library relies on runtime implementations of
+[`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer)
+and
+[`DataView`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView)
+([Structured Data](https://tc39.es/ecma262/multipage/structured-data.html#sec-structured-data)),
+and
+[`TypedArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
+([Indexed Collections](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-indexed-collections)).
+
+If you want to be sure that those implemtations are available in your target
+runtime environment, you might want to consider using a polyfill such as
+[__core-js__ Typed Arrays](https://github.com/zloirock/core-js#ecmascript-typed-arrays).
+
 ## Related packages
 
 These are some other packages which provide more `ArrayBuffer` features.

--- a/src/Data/ArrayBuffer/Typed.js
+++ b/src/Data/ArrayBuffer/Typed.js
@@ -1,24 +1,5 @@
 "use strict";
 
-
-
-// Lightweight polyfill for ie - see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Methods_Polyfill
-function polyFill () {
-    var typedArrayTypes =
-        [ Int8Array, Uint8Array, Uint8ClampedArray, Int16Array
-        , Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array
-        ];
-
-    for (var k in typedArrayTypes) {
-        for (var v in Array.prototype) {
-            if (Array.prototype.hasOwnProperty(v) && !typedArrayTypes[k].prototype.hasOwnProperty(v))
-                typedArrayTypes[k].prototype[v] = Array.prototype[v];
-        }
-    }
-};
-
-polyFill();
-
 // module Data.ArrayBuffer.Typed
 
 exports.buffer = function buffer (v) {


### PR DESCRIPTION
The `polyFill()` for TypedArray was causing problems with `purs bundle`
v0.14.4. https://github.com/purescript-contrib/purescript-arraybuffer/issues/34

The link which the `polyFill()` function referred to is dead.

This link shows what appears to be a fully-functional TypedArray
polyfill, which is not what we had in our library. Was our `polyFill()`
even working at all? I don't know.

https://github.com/zloirock/core-js#ecmascript-typed-arrays

This library will now pass [this test](https://github.com/purescript-contrib/purescript-arraybuffer/issues/34#issuecomment-915289229) for purs 0.14.4, and still passes for 0.14.3.

Resolves #34

There is also #35 to resolve the same issue. We should choose one. I prefer this solution.