### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -38,3 +40,6 @@ jobs:
 
       - name: Run tests
         run: spago -x spago-test.dhall test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/src/Data/ArrayBuffer/ArrayBuffer.purs
+++ b/src/Data/ArrayBuffer/ArrayBuffer.purs
@@ -14,6 +14,7 @@ import Effect.Uncurried (EffectFn1, runEffectFn1)
 -- | Create an `ArrayBuffer` with the given capacity.
 empty :: ByteLength -> Effect ArrayBuffer
 empty l = runEffectFn1 emptyImpl l
+
 foreign import emptyImpl :: EffectFn1 ByteLength ArrayBuffer
 
 -- | Represents the length of an `ArrayBuffer` in bytes.
@@ -22,4 +23,5 @@ foreign import byteLength :: ArrayBuffer -> ByteLength
 -- | Returns a new `ArrayBuffer` whose contents are a copy of this ArrayBuffer's bytes from begin, inclusive, up to end, exclusive.
 slice :: ByteOffset -> ByteOffset -> ArrayBuffer -> ArrayBuffer
 slice s e a = runFn3 sliceImpl a s e
+
 foreign import sliceImpl :: Fn3 ArrayBuffer ByteOffset ByteOffset ArrayBuffer

--- a/src/Data/ArrayBuffer/ArrayBuffer/Gen.purs
+++ b/src/Data/ArrayBuffer/ArrayBuffer/Gen.purs
@@ -6,8 +6,5 @@ import Data.ArrayBuffer.Typed.Gen (genTypedArray, genUint8)
 import Data.ArrayBuffer.Types (ArrayBuffer, Uint8Array)
 import Prelude ((<$>))
 
-genArrayBuffer
-  :: forall m
-   . MonadGen m
-  => m ArrayBuffer
+genArrayBuffer :: forall m. MonadGen m => m ArrayBuffer
 genArrayBuffer = buffer <$> (genTypedArray genUint8 :: m Uint8Array)

--- a/src/Data/ArrayBuffer/ArrayBuffer/Gen.purs
+++ b/src/Data/ArrayBuffer/ArrayBuffer/Gen.purs
@@ -6,8 +6,8 @@ import Data.ArrayBuffer.Typed.Gen (genTypedArray, genUint8)
 import Data.ArrayBuffer.Types (ArrayBuffer, Uint8Array)
 import Prelude ((<$>))
 
-
-genArrayBuffer :: forall m
-                . MonadGen m
-               => m ArrayBuffer
+genArrayBuffer
+  :: forall m
+   . MonadGen m
+  => m ArrayBuffer
 genArrayBuffer = buffer <$> (genTypedArray genUint8 :: m Uint8Array)

--- a/src/Data/ArrayBuffer/DataView.purs
+++ b/src/Data/ArrayBuffer/DataView.purs
@@ -1,48 +1,48 @@
 -- | This module represents the functional bindings to JavaScript's `DataView`
 -- | objects. See [MDN's spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) for details.
 module Data.ArrayBuffer.DataView
-       ( Endian(..)
-       , buffer
-       , byteLength
-       , byteOffset
-       , get
-       , getBE
-       , getFloat32be
-       , getFloat32le
-       , getFloat64be
-       , getFloat64le
-       , getInt16be
-       , getInt16le
-       , getInt32be
-       , getInt32le
-       , getInt8
-       , getLE
-       , getUint16be
-       , getUint16le
-       , getUint32be
-       , getUint32le
-       , getUint8
-       , part
-       , remainder
-       , set
-       , setBE
-       , setFloat32be
-       , setFloat32le
-       , setFloat64be
-       , setFloat64le
-       , setInt16be
-       , setInt16le
-       , setInt32be
-       , setInt32le
-       , setInt8
-       , setLE
-       , setUint16be
-       , setUint16le
-       , setUint32be
-       , setUint32le
-       , setUint8
-       , whole
-       ) where
+  ( Endian(..)
+  , buffer
+  , byteLength
+  , byteOffset
+  , get
+  , getBE
+  , getFloat32be
+  , getFloat32le
+  , getFloat64be
+  , getFloat64le
+  , getInt16be
+  , getInt16le
+  , getInt32be
+  , getInt32le
+  , getInt8
+  , getLE
+  , getUint16be
+  , getUint16le
+  , getUint32be
+  , getUint32le
+  , getUint8
+  , part
+  , remainder
+  , set
+  , setBE
+  , setFloat32be
+  , setFloat32le
+  , setFloat64be
+  , setFloat64le
+  , setInt16be
+  , setInt16le
+  , setInt32be
+  , setInt32le
+  , setInt8
+  , setLE
+  , setUint16be
+  , setUint16le
+  , setUint32be
+  , setUint32le
+  , setUint8
+  , whole
+  ) where
 
 import Data.ArrayBuffer.Types (ArrayBuffer, ByteLength, ByteOffset, DataView, Float32, Float64, Int16, Int32, Int8, Uint16, Uint32, Uint8)
 import Data.ArrayBuffer.ValueMapping (class BinaryValue, class BytesPerType, class ShowArrayViewType, byteWidth)
@@ -67,15 +67,16 @@ instance eqEndian :: Eq Endian where
 -- | View mapping the whole `ArrayBuffer`.
 foreign import whole :: ArrayBuffer -> DataView
 
-
 -- | View mapping the rest of an `ArrayBuffer` after an index.
 remainder :: ArrayBuffer -> ByteOffset -> Effect DataView
 remainder a o = runEffectFn2 remainderImpl a o
+
 foreign import remainderImpl :: EffectFn2 ArrayBuffer ByteOffset DataView
 
 -- | View mapping a region of the `ArrayBuffer`.
 part :: ArrayBuffer -> ByteOffset -> ByteLength -> Effect DataView
 part a o l = runEffectFn3 partImpl a o l
+
 foreign import partImpl :: EffectFn3 ArrayBuffer ByteOffset ByteLength DataView
 
 -- | `ArrayBuffer` being mapped by the view.
@@ -87,86 +88,129 @@ foreign import byteOffset :: DataView -> ByteOffset
 -- | Represents the length of this view.
 foreign import byteLength :: DataView -> ByteLength
 
-
-
-getter :: forall t.
-          { functionName :: String
-          , bytesPerValue :: ByteLength
-          , littleEndian :: Boolean
-          }
-       -> DataView -> ByteOffset -> Effect (Maybe t)
+getter
+  :: forall t
+   . { functionName :: String
+     , bytesPerValue :: ByteLength
+     , littleEndian :: Boolean
+     }
+  -> DataView
+  -> ByteOffset
+  -> Effect (Maybe t)
 getter data' d o = toMaybe <$>
   runEffectFn3 getterImpl
     { functionName: data'.functionName
     , littleEndian: data'.littleEndian
     , bytesPerValue: data'.bytesPerValue
-    } d o
-foreign import getterImpl :: forall t
-                           . EffectFn3 { functionName :: String
-                                       , littleEndian :: Boolean
-                                       , bytesPerValue :: ByteLength
-                                       } DataView ByteOffset (Nullable t)
+    }
+    d
+    o
 
+foreign import getterImpl
+  :: forall t
+   . EffectFn3
+       { functionName :: String
+       , littleEndian :: Boolean
+       , bytesPerValue :: ByteLength
+       }
+       DataView
+       ByteOffset
+       (Nullable t)
 
-
-get :: forall a name t
-     . BinaryValue a t
-    => BytesPerType a
-    => ShowArrayViewType a name
-    => IsSymbol name
-    => Endian -> Proxy a -> DataView -> ByteOffset -> Effect (Maybe t)
+get
+  :: forall a name t
+   . BinaryValue a t
+  => BytesPerType a
+  => ShowArrayViewType a name
+  => IsSymbol name
+  => Endian
+  -> Proxy a
+  -> DataView
+  -> ByteOffset
+  -> Effect (Maybe t)
 get endian prx =
-  let le = endian == LE
-      pnm = "get" <> reflectSymbol (SProxy :: SProxy name)
-      bpv = byteWidth prx
-  in getter { functionName: pnm
-            , bytesPerValue: bpv
-            , littleEndian: le
-            }
+  let
+    le = endian == LE
+    pnm = "get" <> reflectSymbol (SProxy :: SProxy name)
+    bpv = byteWidth prx
+  in
+    getter
+      { functionName: pnm
+      , bytesPerValue: bpv
+      , littleEndian: le
+      }
 
-getBE :: forall a name t
-       . BinaryValue a t
-      => BytesPerType a
-      => ShowArrayViewType a name
-      => IsSymbol name
-      => Proxy a -> DataView -> ByteOffset -> Effect (Maybe t)
+getBE
+  :: forall a name t
+   . BinaryValue a t
+  => BytesPerType a
+  => ShowArrayViewType a name
+  => IsSymbol name
+  => Proxy a
+  -> DataView
+  -> ByteOffset
+  -> Effect (Maybe t)
 getBE = get BE
 
-getLE :: forall a name t
-       . BinaryValue a t
-      => BytesPerType a
-      => ShowArrayViewType a name
-      => IsSymbol name
-      => Proxy a -> DataView -> ByteOffset -> Effect (Maybe t)
+getLE
+  :: forall a name t
+   . BinaryValue a t
+  => BytesPerType a
+  => ShowArrayViewType a name
+  => IsSymbol name
+  => Proxy a
+  -> DataView
+  -> ByteOffset
+  -> Effect (Maybe t)
 getLE = get LE
 
-setter :: forall t.
-          { functionName :: String
-          , bytesPerValue :: ByteLength
-          , littleEndian :: Boolean
-          } -> DataView -> ByteOffset -> t -> Effect Boolean
+setter
+  :: forall t
+   . { functionName :: String
+     , bytesPerValue :: ByteLength
+     , littleEndian :: Boolean
+     }
+  -> DataView
+  -> ByteOffset
+  -> t
+  -> Effect Boolean
 setter d o t = runEffectFn4 setterImpl d o t
-foreign import setterImpl :: forall t
-                           . EffectFn4 { functionName :: String
-                                       , littleEndian :: Boolean
-                                       , bytesPerValue :: ByteLength
-                                       } DataView ByteOffset t Boolean
 
+foreign import setterImpl
+  :: forall t
+   . EffectFn4
+       { functionName :: String
+       , littleEndian :: Boolean
+       , bytesPerValue :: ByteLength
+       }
+       DataView
+       ByteOffset
+       t
+       Boolean
 
-set :: forall a name t
-     . BinaryValue a t
-    => BytesPerType a
-    => ShowArrayViewType a name
-    => IsSymbol name
-    => Endian -> Proxy a -> DataView -> ByteOffset -> t -> Effect Boolean
+set
+  :: forall a name t
+   . BinaryValue a t
+  => BytesPerType a
+  => ShowArrayViewType a name
+  => IsSymbol name
+  => Endian
+  -> Proxy a
+  -> DataView
+  -> ByteOffset
+  -> t
+  -> Effect Boolean
 set endian prx =
-  let le = endian == LE
-      pnm = "set" <> reflectSymbol (SProxy :: SProxy name)
-      bpv = byteWidth prx
-  in setter { functionName: pnm
-            , bytesPerValue: bpv
-            , littleEndian: le
-            }
+  let
+    le = endian == LE
+    pnm = "set" <> reflectSymbol (SProxy :: SProxy name)
+    bpv = byteWidth prx
+  in
+    setter
+      { functionName: pnm
+      , bytesPerValue: bpv
+      , littleEndian: le
+      }
 
 -- | Fetch int8 value at a certain index in a `DataView`.
 getInt8 :: DataView -> ByteOffset -> Effect (Maybe Int)
@@ -224,23 +268,32 @@ getFloat64be = getBE (Proxy :: Proxy Float64)
 getFloat64le :: DataView -> ByteOffset -> Effect (Maybe Number)
 getFloat64le = getLE (Proxy :: Proxy Float64)
 
-
 -- | Store big-endian value at a certain index in a `DataView`.
-setBE :: forall a name t
-       . BinaryValue a t
-      => BytesPerType a
-      => ShowArrayViewType a name
-      => IsSymbol name
-      => Proxy a -> DataView -> ByteOffset -> t -> Effect Boolean
+setBE
+  :: forall a name t
+   . BinaryValue a t
+  => BytesPerType a
+  => ShowArrayViewType a name
+  => IsSymbol name
+  => Proxy a
+  -> DataView
+  -> ByteOffset
+  -> t
+  -> Effect Boolean
 setBE = set BE
 
 -- | Store little-endian value at a certain index in a `DataView`.
-setLE :: forall a name t
-       . BinaryValue a t
-      => BytesPerType a
-      => ShowArrayViewType a name
-      => IsSymbol name
-      => Proxy a -> DataView -> ByteOffset -> t -> Effect Boolean
+setLE
+  :: forall a name t
+   . BinaryValue a t
+  => BytesPerType a
+  => ShowArrayViewType a name
+  => IsSymbol name
+  => Proxy a
+  -> DataView
+  -> ByteOffset
+  -> t
+  -> Effect Boolean
 setLE = set LE
 
 -- | Store int8 value at a certain index in a `DataView`.
@@ -266,7 +319,6 @@ setInt32le = setLE (Proxy :: Proxy Int32)
 -- | Store uint8 value at a certain index in a `DataView`.
 setUint8 :: DataView -> ByteOffset -> UInt -> Effect Boolean
 setUint8 = setLE (Proxy :: Proxy Uint8)
-
 
 -- | Store big-endian uint16 value at a certain index in a `DataView`.
 setUint16be :: DataView -> ByteOffset -> UInt -> Effect Boolean

--- a/src/Data/ArrayBuffer/DataView.purs
+++ b/src/Data/ArrayBuffer/DataView.purs
@@ -97,14 +97,14 @@ getter
   -> DataView
   -> ByteOffset
   -> Effect (Maybe t)
-getter data' d o = toMaybe <$>
-  runEffectFn3 getterImpl
+getter data' dataView offset =
+  toMaybe <$> runEffectFn3 getterImpl
     { functionName: data'.functionName
     , littleEndian: data'.littleEndian
     , bytesPerValue: data'.bytesPerValue
     }
-    d
-    o
+    dataView
+    offset
 
 foreign import getterImpl
   :: forall t
@@ -128,17 +128,17 @@ get
   -> DataView
   -> ByteOffset
   -> Effect (Maybe t)
-get endian prx =
+get endian prx = do
   let
     le = endian == LE
     pnm = "get" <> reflectSymbol (SProxy :: SProxy name)
     bpv = byteWidth prx
-  in
-    getter
-      { functionName: pnm
-      , bytesPerValue: bpv
-      , littleEndian: le
-      }
+
+  getter
+    { functionName: pnm
+    , bytesPerValue: bpv
+    , littleEndian: le
+    }
 
 getBE
   :: forall a name t
@@ -174,7 +174,7 @@ setter
   -> ByteOffset
   -> t
   -> Effect Boolean
-setter d o t = runEffectFn4 setterImpl d o t
+setter dataView offset t = runEffectFn4 setterImpl dataView offset t
 
 foreign import setterImpl
   :: forall t
@@ -200,17 +200,17 @@ set
   -> ByteOffset
   -> t
   -> Effect Boolean
-set endian prx =
+set endian prx = do
   let
     le = endian == LE
     pnm = "set" <> reflectSymbol (SProxy :: SProxy name)
     bpv = byteWidth prx
-  in
-    setter
-      { functionName: pnm
-      , bytesPerValue: bpv
-      , littleEndian: le
-      }
+
+  setter
+    { functionName: pnm
+    , bytesPerValue: bpv
+    , littleEndian: le
+    }
 
 -- | Fetch int8 value at a certain index in a `DataView`.
 getInt8 :: DataView -> ByteOffset -> Effect (Maybe Int)

--- a/src/Data/ArrayBuffer/DataView/Gen.purs
+++ b/src/Data/ArrayBuffer/DataView/Gen.purs
@@ -11,10 +11,7 @@ import Data.Unfoldable (replicateA)
 import Prelude ((<$>), bind, (<=), (-), pure)
 import Type.Proxy (Proxy(..))
 
-genDataView
-  :: forall m
-   . MonadGen m
-  => m DataView
+genDataView :: forall m. MonadGen m => m DataView
 genDataView = whole <$> genArrayBuffer
 
 -- | For generating some set of offsets residing inside the generated array, with some computable value

--- a/src/Data/ArrayBuffer/DataView/Gen.purs
+++ b/src/Data/ArrayBuffer/DataView/Gen.purs
@@ -11,27 +11,26 @@ import Data.Unfoldable (replicateA)
 import Prelude ((<$>), bind, (<=), (-), pure)
 import Type.Proxy (Proxy(..))
 
-
-genDataView :: forall m
-             . MonadGen m
-            => m DataView
+genDataView
+  :: forall m
+   . MonadGen m
+  => m DataView
 genDataView = whole <$> genArrayBuffer
-
-
 
 -- | For generating some set of offsets residing inside the generated array, with some computable value
 data WithOffsetAndValue (a :: ArrayViewType) t =
   WithOffsetAndValue (Array ByteOffset) t DataView
 
-genWithOffsetAndValue :: forall m a t
-                      . MonadGen m
-                      => MonadRec m
-                      => BytesPerType a
-                      => BinaryValue a t
-                      => Int -- generated length
-                      -> m DataView -- ^ Assumes generated length is at least the minimum length of one value
-                      -> m t
-                      -> m (WithOffsetAndValue a t)
+genWithOffsetAndValue
+  :: forall m a t
+   . MonadGen m
+  => MonadRec m
+  => BytesPerType a
+  => BinaryValue a t
+  => Int -- generated length
+  -> m DataView -- ^ Assumes generated length is at least the minimum length of one value
+  -> m t
+  -> m (WithOffsetAndValue a t)
 genWithOffsetAndValue n gen genT = do
   let b = byteWidth (Proxy :: Proxy a)
   xs <- gen `suchThat` \xs -> b <= byteLength xs

--- a/src/Data/ArrayBuffer/Typed.purs
+++ b/src/Data/ArrayBuffer/Typed.purs
@@ -402,12 +402,12 @@ reverse a = runEffectFn1 reverseImpl a
 foreign import reverseImpl :: forall a. EffectFn1 (ArrayView a) Unit
 
 setInternal :: forall a b. (b -> Length) -> ArrayView a -> Maybe Index -> b -> Effect Boolean
-setInternal lenfn a mo b =
-  let
-    o = fromMaybe 0 mo
-  in
-    if o >= 0 && lenfn b <= length a - o then runEffectFn3 setImpl a o b *> pure true
-    else pure false
+setInternal lenfn a mo b = do
+  let o = fromMaybe 0 mo
+  if o >= 0 && lenfn b <= length a - o then
+    runEffectFn3 setImpl a o b *> pure true
+  else
+    pure false
 
 foreign import setImpl :: forall a b. EffectFn3 (ArrayView a) Index b Unit
 

--- a/src/Data/ArrayBuffer/Typed.purs
+++ b/src/Data/ArrayBuffer/Typed.purs
@@ -28,25 +28,65 @@
 -- | - `toString` prints to a CSV, `join` allows you to supply the delimiter
 -- | - `toArray` returns an array of numeric values
 
-
 module Data.ArrayBuffer.Typed
-  ( Index, Length
-  , buffer, byteOffset, byteLength, length
-  , compare, eq
+  ( Index
+  , Length
+  , buffer
+  , byteOffset
+  , byteLength
+  , length
+  , compare
+  , eq
   , class TypedArray
-  , create, whole, remainder, part, empty, fromArray
-  , fill, set, setTyped, copyWithin
-  , map, traverse, traverse_, filter
-  , mapWithIndex, traverseWithIndex, traverseWithIndex_, filterWithIndex
-  , sort, reverse
+  , create
+  , whole
+  , remainder
+  , part
+  , empty
+  , fromArray
+  , fill
+  , set
+  , setTyped
+  , copyWithin
+  , map
+  , traverse
+  , traverse_
+  , filter
+  , mapWithIndex
+  , traverseWithIndex
+  , traverseWithIndex_
+  , filterWithIndex
+  , sort
+  , reverse
   , elem
-  , all, any
-  , allWithIndex, anyWithIndex
-  , unsafeAt, hasIndex, at, (!)
-  , reduce, reduce1, foldl, foldl1, reduceRight, reduceRight1, foldr, foldr1, foldlWithIndex, foldrWithIndex
-  , find, findIndex, findWithIndex, indexOf, lastIndexOf
-  , slice, subArray
-  , toString, join, toArray
+  , all
+  , any
+  , allWithIndex
+  , anyWithIndex
+  , unsafeAt
+  , hasIndex
+  , at
+  , (!)
+  , reduce
+  , reduce1
+  , foldl
+  , foldl1
+  , reduceRight
+  , reduceRight1
+  , foldr
+  , foldr1
+  , foldlWithIndex
+  , foldrWithIndex
+  , find
+  , findIndex
+  , findWithIndex
+  , indexOf
+  , lastIndexOf
+  , slice
+  , subArray
+  , toString
+  , join
+  , toArray
   ) where
 
 import Data.Array (length) as A
@@ -64,7 +104,6 @@ import Prelude (class Eq, class Ord, Ordering, Unit, flip, pure, ($), (&&), (*),
 import Prelude as Prelude
 import Type.Proxy (Proxy(..))
 
-
 -- | `ArrayBuffer` being mapped by the typed array.
 foreign import buffer :: forall a. ArrayView a -> ArrayBuffer
 
@@ -77,6 +116,7 @@ foreign import byteLength :: forall a. ArrayView a -> ByteLength
 -- | Represents the number of elements in this typed array.
 length :: forall a. ArrayView a -> Length
 length = lengthImpl
+
 foreign import lengthImpl :: forall a. ArrayView a -> Length
 
 -- object creator implementations for each typed array
@@ -91,32 +131,38 @@ foreign import newInt8Array :: forall a. EffectFn3 a (Nullable ByteOffset) (Null
 foreign import newFloat32Array :: forall a. EffectFn3 a (Nullable ByteOffset) (Nullable ByteLength) Float32Array
 foreign import newFloat64Array :: forall a. EffectFn3 a (Nullable ByteOffset) (Nullable ByteLength) Float64Array
 
-
 -- | Value-oriented array index.
 type Index = Int
 -- | Value-oriented array length.
 type Length = Int
-
 
 class BinaryValue a t <= TypedArray (a :: ArrayViewType) (t :: Type) | a -> t where
   create :: forall x. EffectFn3 x (Nullable ByteOffset) (Nullable ByteLength) (ArrayView a)
 
 instance typedArrayUint8Clamped :: TypedArray Uint8Clamped UInt where
   create = newUint8ClampedArray
+
 instance typedArrayUint32 :: TypedArray Uint32 UInt where
   create = newUint32Array
+
 instance typedArrayUint16 :: TypedArray Uint16 UInt where
   create = newUint16Array
+
 instance typedArrayUint8 :: TypedArray Uint8 UInt where
   create = newUint8Array
+
 instance typedArrayInt32 :: TypedArray Int32 Int where
   create = newInt32Array
+
 instance typedArrayInt16 :: TypedArray Int16 Int where
   create = newInt16Array
+
 instance typedArrayInt8 :: TypedArray Int8 Int where
   create = newInt8Array
+
 instance typedArrayFloat32 :: TypedArray Float32 F.Float32 where
   create = newFloat32Array
+
 instance typedArrayFloat64 :: TypedArray Float64 Number where
   create = newFloat64Array
 
@@ -127,7 +173,8 @@ whole a = runEffectFn3 create a null null
 -- | View mapping the rest of an `ArrayBuffer` after an index.
 remainder :: forall a b t. TypedArray a t => BytesPerType b => ArrayBuffer -> Index -> Effect (ArrayView a)
 remainder a x = remainder' a o
-  where o = x * byteWidth (Proxy :: Proxy b)
+  where
+  o = x * byteWidth (Proxy :: Proxy b)
 
 remainder' :: forall a t. TypedArray a t => ArrayBuffer -> ByteOffset -> Effect (ArrayView a)
 remainder' a x = runEffectFn3 create a (notNull x) null
@@ -135,7 +182,8 @@ remainder' a x = runEffectFn3 create a (notNull x) null
 -- | View mapping a region of the `ArrayBuffer`.
 part :: forall a t. TypedArray a t => BytesPerType a => ArrayBuffer -> Index -> Length -> Effect (ArrayView a)
 part a x y = part' a o y
-  where o = x * byteWidth (Proxy :: Proxy a)
+  where
+  o = x * byteWidth (Proxy :: Proxy a)
 
 -- | The ByteOffset must be aligned.
 -- | https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#byteoffset_must_be_aligned
@@ -153,6 +201,7 @@ fromArray a = runEffectFn3 create a null null
 -- | Fill the array with a value.
 fill :: forall a t. TypedArray a t => t -> Index -> Index -> ArrayView a -> Effect Unit
 fill x s e a = runEffectFn4 fillImpl x s e a
+
 foreign import fillImpl :: forall a b. EffectFn4 b Index Index (ArrayView a) Unit
 
 -- | Stores multiple values into the typed array.
@@ -161,7 +210,6 @@ set = setInternal A.length
 
 ap1 :: forall a b c. (a -> c) -> (a -> b -> c)
 ap1 f = \x _ -> f x
-
 
 -- | Maps a new value over the typed array, creating a new buffer and
 -- | typed array as well.
@@ -176,6 +224,7 @@ mapWithIndex = mapWithIndex' <<< flip
 
 mapWithIndex' :: forall a t. TypedArray a t => (t -> Index -> t) -> ArrayView a -> ArrayView a
 mapWithIndex' f a = unsafePerformEffect (runEffectFn2 mapImpl a (mkEffectFn2 \x o -> pure (f x o)))
+
 foreign import mapImpl :: forall a b. EffectFn2 (ArrayView a) (EffectFn2 b Index b) (ArrayView a)
 
 -- | Traverses over each value, returning a new one.
@@ -199,6 +248,7 @@ traverseWithIndex_ = traverseWithIndex_' <<< flip
 
 traverseWithIndex_' :: forall a t. TypedArray a t => (t -> Index -> Effect Unit) -> ArrayView a -> Effect Unit
 traverseWithIndex_' f a = runEffectFn2 forEachImpl a (mkEffectFn2 f)
+
 foreign import forEachImpl :: forall a b. EffectFn2 (ArrayView a) (EffectFn2 b Index Unit) Unit
 
 -- | Test a predicate to pass on all values.
@@ -212,6 +262,7 @@ allWithIndex = every <<< flip
 
 every :: forall a t. TypedArray a t => (t -> Index -> Boolean) -> ArrayView a -> Effect Boolean
 every p a = runEffectFn2 everyImpl a (mkFn2 p)
+
 foreign import everyImpl :: forall a b. EffectFn2 (ArrayView a) (Fn2 b Index Boolean) Boolean
 
 -- | Test a predicate to pass on any value.
@@ -224,6 +275,7 @@ anyWithIndex = some <<< flip
 
 some :: forall a t. TypedArray a t => (t -> Index -> Boolean) -> ArrayView a -> Effect Boolean
 some p a = runEffectFn2 someImpl a (mkFn2 p)
+
 foreign import someImpl :: forall a b. EffectFn2 (ArrayView a) (Fn2 b Index Boolean) Boolean
 
 -- | Returns a new typed array with all values that pass the predicate.
@@ -238,11 +290,13 @@ filterWithIndex = filterWithIndex' <<< flip
 
 filterWithIndex' :: forall a t. TypedArray a t => (t -> Index -> Boolean) -> ArrayView a -> Effect (ArrayView a)
 filterWithIndex' p a = runEffectFn2 filterImpl a (mkFn2 p)
+
 foreign import filterImpl :: forall a b. EffectFn2 (ArrayView a) (Fn2 b Index Boolean) (ArrayView a)
 
 -- | Tests if a value is an element of the typed array.
 elem :: forall a t. TypedArray a t => t -> Maybe Index -> ArrayView a -> Effect Boolean
 elem x mo a = runEffectFn3 includesImpl a x (toNullable mo)
+
 foreign import includesImpl :: forall a b. EffectFn3 (ArrayView a) b (Nullable Index) Boolean
 
 -- | Fetch element at index.
@@ -252,21 +306,25 @@ unsafeAt a o = runEffectFn2 unsafeAtImpl a o
 -- | Folding from the left.
 reduce :: forall a t b. TypedArray a t => (b -> t -> Index -> Effect b) -> b -> ArrayView a -> Effect b
 reduce f i a = runEffectFn3 reduceImpl a (mkEffectFn3 f) i
+
 foreign import reduceImpl :: forall a b c. EffectFn3 (ArrayView a) (EffectFn3 c b Index c) c c
 
 -- | Folding from the left. Assumes the typed array is non-empty.
 reduce1 :: forall a t. Partial => TypedArray a t => (t -> t -> Index -> Effect t) -> ArrayView a -> Effect t
 reduce1 f a = runEffectFn2 reduce1Impl a (mkEffectFn3 f)
+
 foreign import reduce1Impl :: forall a b. EffectFn2 (ArrayView a) (EffectFn3 b b Index b) b
 
 -- | Folding from the right.
 reduceRight :: forall a t b. TypedArray a t => (t -> b -> Index -> Effect b) -> b -> ArrayView a -> Effect b
 reduceRight f i a = runEffectFn3 reduceRightImpl a (mkEffectFn3 \acc x o -> f x acc o) i
+
 foreign import reduceRightImpl :: forall a b c. EffectFn3 (ArrayView a) (EffectFn3 c b Index c) c c
 
 -- | Folding from the right. Assumes the typed array is non-empty.
 reduceRight1 :: forall a t. Partial => TypedArray a t => (t -> t -> Index -> Effect t) -> ArrayView a -> Effect t
 reduceRight1 f a = runEffectFn2 reduceRight1Impl a (mkEffectFn3 \acc x o -> f x acc o)
+
 foreign import reduceRight1Impl :: forall a b. EffectFn2 (ArrayView a) (EffectFn3 b b Index b) b
 
 -- | Returns the first value satisfying the predicate.
@@ -280,21 +338,25 @@ findWithIndex = findWithIndex' <<< flip
 
 findWithIndex' :: forall a t. TypedArray a t => (t -> Index -> Boolean) -> ArrayView a -> Effect (Maybe t)
 findWithIndex' f a = toMaybe <$> runEffectFn2 findImpl a (mkFn2 f)
+
 foreign import findImpl :: forall a b. EffectFn2 (ArrayView a) (Fn2 b Index Boolean) (Nullable b)
 
 -- | Returns the first index of the value satisfying the predicate.
 findIndex :: forall a t. TypedArray a t => (t -> Index -> Boolean) -> ArrayView a -> Effect (Maybe Index)
 findIndex f a = toMaybe <$> runEffectFn2 findIndexImpl a (mkFn2 f)
+
 foreign import findIndexImpl :: forall a b. EffectFn2 (ArrayView a) (Fn2 b Index Boolean) (Nullable Index)
 
 -- | Returns the first index of the element, if it exists, from the left.
 indexOf :: forall a t. TypedArray a t => t -> Maybe Index -> ArrayView a -> Effect (Maybe Index)
 indexOf x mo a = toMaybe <$> runEffectFn3 indexOfImpl a x (toNullable mo)
+
 foreign import indexOfImpl :: forall a b. EffectFn3 (ArrayView a) b (Nullable Index) (Nullable Index)
 
 -- | Returns the first index of the element, if it exists, from the right.
 lastIndexOf :: forall a t. TypedArray a t => t -> Maybe Index -> ArrayView a -> Effect (Maybe Index)
 lastIndexOf x mo a = toMaybe <$> runEffectFn3 lastIndexOfImpl a x (toNullable mo)
+
 foreign import lastIndexOfImpl :: forall a b. EffectFn3 (ArrayView a) b (Nullable Index) (Nullable Index)
 
 -- | Fold a list from the left, accumulating the result using the
@@ -330,23 +392,24 @@ foldr1 f = reduceRight1 \x a _ -> pure $ f a x
 -- | Internally copy values - see [MDN's spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin) for details.
 copyWithin :: forall a. ArrayView a -> Index -> Index -> Maybe Index -> Effect Unit
 copyWithin a t s me = runEffectFn4 copyWithinImpl a t s (toNullable me)
+
 foreign import copyWithinImpl :: forall a. EffectFn4 (ArrayView a) Index Index (Nullable Index) Unit
 
 -- | Reverses a typed array in-place.
 reverse :: forall a. ArrayView a -> Effect Unit
 reverse a = runEffectFn1 reverseImpl a
-foreign import reverseImpl :: forall a. EffectFn1 (ArrayView a) Unit
 
+foreign import reverseImpl :: forall a. EffectFn1 (ArrayView a) Unit
 
 setInternal :: forall a b. (b -> Length) -> ArrayView a -> Maybe Index -> b -> Effect Boolean
 setInternal lenfn a mo b =
-  let o = fromMaybe 0 mo
-  in if o >= 0 && lenfn b <= length a - o
-     then runEffectFn3 setImpl a o b *> pure true
-     else pure false
+  let
+    o = fromMaybe 0 mo
+  in
+    if o >= 0 && lenfn b <= length a - o then runEffectFn3 setImpl a o b *> pure true
+    else pure false
+
 foreign import setImpl :: forall a b. EffectFn3 (ArrayView a) Index b Unit
-
-
 
 -- | Stores multiple values in the typed array, reading input values from the second typed array.
 setTyped :: forall a. ArrayView a -> Maybe Index -> ArrayView a -> Effect Boolean
@@ -355,36 +418,43 @@ setTyped = setInternal length
 -- | Copy part of the contents of a typed array into a new buffer, between some start and end indices.
 slice :: forall a. Index -> Index -> ArrayView a -> Effect (ArrayView a)
 slice s e a = runEffectFn3 sliceImpl a s e
+
 foreign import sliceImpl :: forall a. EffectFn3 (ArrayView a) Index Index (ArrayView a)
 
 -- | Sorts the values in-place.
 sort :: forall a. ArrayView a -> Effect Unit
 sort a = runEffectFn1 sortImpl a
+
 foreign import sortImpl :: forall a. EffectFn1 (ArrayView a) Unit
 
 -- | Returns a new typed array view of the same buffer, beginning at the index and ending at the second.
 subArray :: forall a. Index -> Index -> ArrayView a -> ArrayView a
 subArray s e a = runFn3 subArrayImpl a s e
+
 foreign import subArrayImpl :: forall a. Fn3 (ArrayView a) Index Index (ArrayView a)
 
 -- | Prints array to a comma-separated string - see [MDN's spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toString) for details.
 toString :: forall a. ArrayView a -> Effect String
 toString a = runEffectFn1 toStringImpl a
+
 foreign import toStringImpl :: forall a. EffectFn1 (ArrayView a) String
 
 -- | Prints array to a delimiter-separated string - see [MDN's spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/join) for details.
 join :: forall a. String -> ArrayView a -> Effect String
 join s a = runEffectFn2 joinImpl a s
+
 foreign import joinImpl :: forall a. EffectFn2 (ArrayView a) String String
 
 -- | Determine if a certain index is valid.
 hasIndex :: forall a. ArrayView a -> Index -> Boolean
 hasIndex a o = runFn2 hasIndexImpl a o
+
 foreign import hasIndexImpl :: forall a. Fn2 (ArrayView a) Index Boolean
 
 -- | Fetch element at index.
 at :: forall a t. TypedArray a t => ArrayView a -> Index -> Effect (Maybe t)
 at a n = toMaybe <$> runEffectFn2 unsafeAtImpl a n
+
 foreign import unsafeAtImpl :: forall a b. EffectFn2 (ArrayView a) Index b
 
 infixl 3 at as !
@@ -392,6 +462,7 @@ infixl 3 at as !
 -- | Turn typed array into an array.
 toArray :: forall a t. TypedArray a t => ArrayView a -> Effect (Array t)
 toArray a = runEffectFn1 toArrayImpl a
+
 foreign import toArrayImpl :: forall a b. EffectFn1 (ArrayView a) (Array b)
 
 -- | Compare 2 typed arrays.

--- a/src/Data/ArrayBuffer/Typed/Gen.purs
+++ b/src/Data/ArrayBuffer/Typed/Gen.purs
@@ -14,12 +14,12 @@ import Data.Unfoldable (replicateA)
 import Effect.Unsafe (unsafePerformEffect)
 import Prelude (bind, bottom, negate, pure, top, ($), (-), (/), (<$>))
 
-
-genTypedArray :: forall m a t
-               . MonadGen m
-              => TypedArray a t
-              => m t
-              -> m (ArrayView a)
+genTypedArray
+  :: forall m a t
+   . MonadGen m
+  => TypedArray a t
+  => m t
+  -> m (ArrayView a)
 genTypedArray gen = sized \s -> do
   n <- chooseInt 0 s
   a <- replicateA n gen
@@ -47,18 +47,20 @@ genFloat32 :: forall m. MonadGen m => m F.Float32
 genFloat32 = F.fromNumber' <$> chooseFloat (-3.40282347e+38) 3.40282347e+38
 
 genFloat64 :: forall m. MonadGen m => m Number
-genFloat64 = chooseFloat ((-1.7976931348623157e+308)/div) (1.7976931348623157e+308/div)
-  where div = 4.0
+genFloat64 = chooseFloat ((-1.7976931348623157e+308) / div) (1.7976931348623157e+308 / div)
+  where
+  div = 4.0
 
 -- | For generating some set of offsets residing inside the generated array
 data WithIndices a = WithIndices (Array TA.Index) (ArrayView a)
 
-genWithIndices :: forall m a
-               . MonadGen m
-              => BytesPerType a
-              => Int -- Number of offsets residing inside the generated array
-              -> m (ArrayView a)
-              -> m (WithIndices a)
+genWithIndices
+  :: forall m a
+   . MonadGen m
+  => BytesPerType a
+  => Int -- Number of offsets residing inside the generated array
+  -> m (ArrayView a)
+  -> m (WithIndices a)
 genWithIndices n gen = do
   xs <- gen
   let l = TA.length xs

--- a/src/Data/ArrayBuffer/ValueMapping.purs
+++ b/src/Data/ArrayBuffer/ValueMapping.purs
@@ -1,12 +1,11 @@
 -- | This module represents type-level mappings between `ArrayViewType`s
 -- | and meaningful data.
 module Data.ArrayBuffer.ValueMapping
-       ( class BytesPerType
-       , byteWidth
-       , class BinaryValue
-       , class ShowArrayViewType
-       )
-where
+  ( class BytesPerType
+  , byteWidth
+  , class BinaryValue
+  , class ShowArrayViewType
+  ) where
 
 import Data.ArrayBuffer.Types (ArrayViewType, Float32, Float64, Int16, Int32, Int8, Uint16, Uint32, Uint8, Uint8Clamped)
 import Data.Float32 (Float32) as F
@@ -17,15 +16,32 @@ import Type.Proxy (Proxy)
 class BytesPerType (a :: ArrayViewType) where
   byteWidth :: (Proxy a) -> Int
 
-instance bytesPerTypeInt8 :: BytesPerType Int8 where byteWidth _ = 1
-instance bytesPerTypeInt16 :: BytesPerType Int16 where byteWidth _ = 2
-instance bytesPerTypeInt32 :: BytesPerType Int32 where byteWidth _ = 4
-instance bytesPerTypeUint8 :: BytesPerType Uint8 where byteWidth _ = 1
-instance bytesPerTypeUint16 :: BytesPerType Uint16 where byteWidth _ = 2
-instance bytesPerTypeUint32 :: BytesPerType Uint32 where byteWidth _ = 4
-instance bytesPerTypeUint8Clamped :: BytesPerType Uint8Clamped where byteWidth _ = 1
-instance bytesPerTypeFloat32 :: BytesPerType Float32 where byteWidth _ = 4
-instance bytesPerTypeFloat64 :: BytesPerType Float64 where byteWidth _ = 8
+instance bytesPerTypeInt8 :: BytesPerType Int8 where
+  byteWidth _ = 1
+
+instance bytesPerTypeInt16 :: BytesPerType Int16 where
+  byteWidth _ = 2
+
+instance bytesPerTypeInt32 :: BytesPerType Int32 where
+  byteWidth _ = 4
+
+instance bytesPerTypeUint8 :: BytesPerType Uint8 where
+  byteWidth _ = 1
+
+instance bytesPerTypeUint16 :: BytesPerType Uint16 where
+  byteWidth _ = 2
+
+instance bytesPerTypeUint32 :: BytesPerType Uint32 where
+  byteWidth _ = 4
+
+instance bytesPerTypeUint8Clamped :: BytesPerType Uint8Clamped where
+  byteWidth _ = 1
+
+instance bytesPerTypeFloat32 :: BytesPerType Float32 where
+  byteWidth _ = 4
+
+instance bytesPerTypeFloat64 :: BytesPerType Float64 where
+  byteWidth _ = 8
 
 -- | Maps a `TypedArray`’s binary casted value to its computable representation in JavaScript.
 class BinaryValue (a :: ArrayViewType) (t :: Type) | a -> t
@@ -41,6 +57,7 @@ instance binaryValueFloat32 :: BinaryValue Float32 F.Float32
 instance binaryValueFloat64 :: BinaryValue Float64 Number
 
 class ShowArrayViewType (a :: ArrayViewType) (name :: Symbol) | a -> name
+
 instance showArrayViewTypeUint8Clamped :: ShowArrayViewType Uint8Clamped "Uint8Clamped"
 instance showArrayViewTypeViewUint32 :: ShowArrayViewType Uint32 "Uint32"
 instance showArrayViewTypeViewUint16 :: ShowArrayViewType Uint16 "Uint16"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -8,6 +8,5 @@ import Test.Properties (propertiesTests)
 
 main :: Effect Unit
 main = do
-
   log "Starting tests..."
   propertiesTests

--- a/test/Properties.purs
+++ b/test/Properties.purs
@@ -8,7 +8,6 @@ import Test.Properties.DataView (dataViewTests)
 import Test.Properties.TypedArray (typedArrayTests)
 import Test.Properties.Typed.Laws (typedArrayLaws)
 
-
 propertiesTests :: Effect Unit
 propertiesTests = do
   do

--- a/test/Properties/ArrayBuffer.purs
+++ b/test/Properties/ArrayBuffer.purs
@@ -1,2 +1,1 @@
 module Test.Properties.ArrayBuffer where
-

--- a/test/Properties/DataView.purs
+++ b/test/Properties/DataView.purs
@@ -49,79 +49,79 @@ overAll
 overAll count f = do
   void (Ref.modify (_ + 1) count)
   log "      - Uint32"
-  quickCheckGen $
+  quickCheckGen do
     let
       f' :: TestableViewF Uint32 "Uint32" UInt q
       f' = f
-    in
-      f' <$> genWithOffsetAndValue 4 genDataView genUint32
+
+    f' <$> genWithOffsetAndValue 4 genDataView genUint32
 
   log "      - Uint16"
-  quickCheckGen $
+  quickCheckGen do
     let
       f' :: TestableViewF Uint16 "Uint16" UInt q
       f' = f
-    in
-      f' <$> genWithOffsetAndValue 2 genDataView genUint16
+
+    f' <$> genWithOffsetAndValue 2 genDataView genUint16
 
   log "      - Uint8"
-  quickCheckGen $
+  quickCheckGen do
     let
       f' :: TestableViewF Uint8 "Uint8" UInt q
       f' = f
-    in
-      f' <$> genWithOffsetAndValue 1 genDataView genUint8
+
+    f' <$> genWithOffsetAndValue 1 genDataView genUint8
 
   log "      - Int32"
-  quickCheckGen $
+  quickCheckGen do
     let
       f' :: TestableViewF Int32 "Int32" Int q
       f' = f
-    in
-      f' <$> genWithOffsetAndValue 4 genDataView genInt32
+
+    f' <$> genWithOffsetAndValue 4 genDataView genInt32
 
   log "      - Int16"
-  quickCheckGen $
+  quickCheckGen do
     let
       f' :: TestableViewF Int16 "Int16" Int q
       f' = f
-    in
-      f' <$> genWithOffsetAndValue 2 genDataView genInt16
+
+    f' <$> genWithOffsetAndValue 2 genDataView genInt16
 
   log "      - Int8"
-  quickCheckGen $
+  quickCheckGen do
     let
       f' :: TestableViewF Int8 "Int8" Int q
       f' = f
-    in
-      f' <$> genWithOffsetAndValue 1 genDataView genInt8
+
+    f' <$> genWithOffsetAndValue 1 genDataView genInt8
 
   log "      - Float32"
-  quickCheckGen $
+  quickCheckGen do
     let
       f' :: TestableViewF Float32 "Float32" F.Float32 q
       f' = f
-    in
-      f' <$> genWithOffsetAndValue 4 genDataView genFloat32
+
+    f' <$> genWithOffsetAndValue 4 genDataView genFloat32
 
   log "      - Float64"
-  quickCheckGen $
+  quickCheckGen do
     let
       f' :: TestableViewF Float64 "Float64" Number q
       f' = f
-    in
-      f' <$> genWithOffsetAndValue 8 genDataView genFloat64
+
+    f' <$> genWithOffsetAndValue 8 genDataView genFloat64
 
 placingAValueIsThereTests :: DV.Endian -> Ref Int -> Effect Unit
 placingAValueIsThereTests endian count = overAll count placingAValueIsThere
   where
   placingAValueIsThere :: forall a name t. TestableViewF a name t Result
-  placingAValueIsThere (WithOffsetAndValue os t xs) =
+  placingAValueIsThere (WithOffsetAndValue os t xs) = do
     let
       o = unsafePartial $ Array.head os
       prx = Proxy :: Proxy a
-    in
-      unsafePerformEffect do
-        _ <- DV.set endian prx xs o t
-        my <- DV.get endian prx xs o
-        pure (my === Just t)
+
+    unsafePerformEffect do
+      _ <- DV.set endian prx xs o t
+      my <- DV.get endian prx xs o
+      pure (my === Just t)

--- a/test/Properties/DataView.purs
+++ b/test/Properties/DataView.purs
@@ -21,7 +21,6 @@ import Partial.Unsafe (unsafePartial)
 import Test.QuickCheck (class Testable, quickCheckGen, Result, (===))
 import Type.Proxy (Proxy(..))
 
-
 dataViewTests :: Ref Int -> Effect Unit
 dataViewTests count = do
   log "    - setBE x o => getBE o === Just x"
@@ -29,9 +28,8 @@ dataViewTests count = do
   log "    - setLE x o => getLE o === Just x"
   placingAValueIsThereTests DV.LE count
 
-
 type TestableViewF a name t q =
-     Show t
+  Show t
   => Eq t
   => Ord t
   => Semiring t
@@ -42,68 +40,88 @@ type TestableViewF a name t q =
   => WithOffsetAndValue a t
   -> q
 
-
-overAll :: forall q . Testable q
-        => Ref Int -> (forall a name t. TestableViewF a name t q) -> Effect Unit
+overAll
+  :: forall q
+   . Testable q
+  => Ref Int
+  -> (forall a name t. TestableViewF a name t q)
+  -> Effect Unit
 overAll count f = do
   void (Ref.modify (_ + 1) count)
   log "      - Uint32"
   quickCheckGen $
-    let f' :: TestableViewF Uint32 "Uint32" UInt q
-        f' = f
-    in  f' <$> genWithOffsetAndValue 4 genDataView genUint32
+    let
+      f' :: TestableViewF Uint32 "Uint32" UInt q
+      f' = f
+    in
+      f' <$> genWithOffsetAndValue 4 genDataView genUint32
 
   log "      - Uint16"
   quickCheckGen $
-    let f' :: TestableViewF Uint16 "Uint16" UInt q
-        f' = f
-    in  f' <$> genWithOffsetAndValue 2 genDataView genUint16
+    let
+      f' :: TestableViewF Uint16 "Uint16" UInt q
+      f' = f
+    in
+      f' <$> genWithOffsetAndValue 2 genDataView genUint16
 
   log "      - Uint8"
   quickCheckGen $
-    let f' :: TestableViewF Uint8 "Uint8" UInt q
-        f' = f
-    in  f' <$> genWithOffsetAndValue 1 genDataView genUint8
+    let
+      f' :: TestableViewF Uint8 "Uint8" UInt q
+      f' = f
+    in
+      f' <$> genWithOffsetAndValue 1 genDataView genUint8
 
   log "      - Int32"
   quickCheckGen $
-    let f' :: TestableViewF Int32 "Int32" Int q
-        f' = f
-    in  f' <$> genWithOffsetAndValue 4 genDataView genInt32
+    let
+      f' :: TestableViewF Int32 "Int32" Int q
+      f' = f
+    in
+      f' <$> genWithOffsetAndValue 4 genDataView genInt32
 
   log "      - Int16"
   quickCheckGen $
-    let f' :: TestableViewF Int16 "Int16" Int q
-        f' = f
-    in  f' <$> genWithOffsetAndValue 2 genDataView genInt16
+    let
+      f' :: TestableViewF Int16 "Int16" Int q
+      f' = f
+    in
+      f' <$> genWithOffsetAndValue 2 genDataView genInt16
 
   log "      - Int8"
   quickCheckGen $
-    let f' :: TestableViewF Int8 "Int8" Int q
-        f' = f
-    in  f' <$> genWithOffsetAndValue 1 genDataView genInt8
+    let
+      f' :: TestableViewF Int8 "Int8" Int q
+      f' = f
+    in
+      f' <$> genWithOffsetAndValue 1 genDataView genInt8
 
   log "      - Float32"
   quickCheckGen $
-    let f' :: TestableViewF Float32 "Float32" F.Float32 q
-        f' = f
-    in  f' <$> genWithOffsetAndValue 4 genDataView genFloat32
+    let
+      f' :: TestableViewF Float32 "Float32" F.Float32 q
+      f' = f
+    in
+      f' <$> genWithOffsetAndValue 4 genDataView genFloat32
 
   log "      - Float64"
   quickCheckGen $
-    let f' :: TestableViewF Float64 "Float64" Number q
-        f' = f
-    in  f' <$> genWithOffsetAndValue 8 genDataView genFloat64
-
+    let
+      f' :: TestableViewF Float64 "Float64" Number q
+      f' = f
+    in
+      f' <$> genWithOffsetAndValue 8 genDataView genFloat64
 
 placingAValueIsThereTests :: DV.Endian -> Ref Int -> Effect Unit
 placingAValueIsThereTests endian count = overAll count placingAValueIsThere
   where
-    placingAValueIsThere :: forall a name t. TestableViewF a name t Result
-    placingAValueIsThere (WithOffsetAndValue os t xs) =
-      let o = unsafePartial $ Array.head os
-          prx = Proxy :: Proxy a
-      in  unsafePerformEffect do
+  placingAValueIsThere :: forall a name t. TestableViewF a name t Result
+  placingAValueIsThere (WithOffsetAndValue os t xs) =
+    let
+      o = unsafePartial $ Array.head os
+      prx = Proxy :: Proxy a
+    in
+      unsafePerformEffect do
         _ <- DV.set endian prx xs o t
         my <- DV.get endian prx xs o
         pure (my === Just t)

--- a/test/Properties/Typed/Laws.purs
+++ b/test/Properties/Typed/Laws.purs
@@ -1,8 +1,6 @@
 module Test.Properties.Typed.Laws where
 
 import Prelude
--- import Prelude (class Eq, class Monoid, class Ord, class Semigroup, class Show, bind, discard, pure, void, ($), (+), (<>), (<$>))
--- import Prelude (class Eq, class Monoid, class Ord, class Semigroup, Unit, discard, void, ($), (+), (<$>), (<<<))
 import Data.ArrayBuffer.Typed (class TypedArray, toString)
 import Data.ArrayBuffer.Typed.Gen (genFloat32, genFloat64, genInt16, genInt32, genInt8, genTypedArray, genUint16, genUint32, genUint8)
 import Data.ArrayBuffer.Types (ArrayView, Float32, Float64, Int16, Int32, Int8, Uint16, Uint32, Uint8, Uint8Clamped, ArrayViewType)

--- a/test/Properties/Typed/Laws.purs
+++ b/test/Properties/Typed/Laws.purs
@@ -29,20 +29,28 @@ class ArrayEl (a :: ArrayViewType) (t :: Type) where
 
 instance arrayElUint8Clamped :: ArrayEl Uint8Clamped UInt where
   arb _ = genUint8
+
 instance arrayElUint32 :: ArrayEl Uint32 UInt where
   arb _ = genUint32
+
 instance arrayElUint16 :: ArrayEl Uint16 UInt where
   arb _ = genUint16
+
 instance arrayElUint8 :: ArrayEl Uint8 UInt where
   arb _ = genUint8
+
 instance arrayElInt32 :: ArrayEl Int32 Int where
   arb _ = genInt32
+
 instance arrayElInt16 :: ArrayEl Int16 Int where
   arb _ = genInt16
+
 instance arrayElInt8 :: ArrayEl Int8 Int where
   arb _ = genInt8
+
 instance arrayElFloat32 :: ArrayEl Float32 F.Float32 where
   arb _ = genFloat32
+
 instance arrayElFloat64 :: ArrayEl Float64 Number where
   arb _ = genFloat64
 
@@ -121,12 +129,14 @@ instance eqArrayView :: (TypedArray a t, Eq t) => Eq (AV a t) where
 
 instance showArrayView :: (TypedArray a t, Show t) => Show (AV a t) where
   show (AV a) = "T[" <> s <> "]"
-    where s = unsafePerformEffect $ toString a
+    where
+    s = unsafePerformEffect $ toString a
 
 instance semigroupArrayView :: TypedArray a t => Semigroup (AV a t) where
   append (AV a) (AV b) = unsafePerformEffect do
-    let la = TA.length a
-        lb = TA.length b
+    let
+      la = TA.length a
+      lb = TA.length b
     r <- TA.empty $ la + lb
     void $ TA.setTyped r (Just 0) a
     void $ TA.setTyped r (Just la) b

--- a/test/Properties/TypedArray.purs
+++ b/test/Properties/TypedArray.purs
@@ -1,6 +1,5 @@
 module Test.Properties.TypedArray where
 
-
 import Prelude
 
 import Control.Monad.Gen (suchThat)
@@ -107,9 +106,8 @@ typedArrayTests count = do
   log "    - copyWithin o x == setTyped x (slice o x)"
   copyWithinViaSetTypedTests count
 
-
 type TestableArrayF a t q =
-     Show t
+  Show t
   => Eq t
   => Ord t
   => Semiring t
@@ -119,31 +117,36 @@ type TestableArrayF a t q =
   -> Effect q
 
 overAll'
-  :: forall q. Testable q
+  :: forall q
+   . Testable q
   => Int -- n
   -> Int -- “minimum n”?
-  -> Ref Int -> (forall a t. TestableArrayF a t q) -> Effect Unit
+  -> Ref Int
+  -> (forall a t. TestableArrayF a t q)
+  -> Effect Unit
 overAll' n mn count f = do
   void (Ref.modify (_ + 1) count)
 
-  let chk
-        :: forall a t
-        . Show t
-        => Eq t
-        => Ord t
-        => Semiring t
-        => BytesPerType a
-        => TypedArray a t
-        => String
-        -> Int
-        -> Proxy (ArrayView a)
-        -> Gen t
-        -> Effect Unit
-      chk s n' _ gen = do
-        log $ "      - " <> s
-        quickCheckGen $ unsafePerformEffect <<< f <$> genWithIndices n' arr
-        where arr :: Gen (ArrayView a)
-              arr = genTypedArray gen `suchThat` \xs -> mn <= TA.length xs
+  let
+    chk
+      :: forall a t
+       . Show t
+      => Eq t
+      => Ord t
+      => Semiring t
+      => BytesPerType a
+      => TypedArray a t
+      => String
+      -> Int
+      -> Proxy (ArrayView a)
+      -> Gen t
+      -> Effect Unit
+    chk s n' _ gen = do
+      log $ "      - " <> s
+      quickCheckGen $ unsafePerformEffect <<< f <$> genWithIndices n' arr
+      where
+      arr :: Gen (ArrayView a)
+      arr = genTypedArray gen `suchThat` \xs -> mn <= TA.length xs
 
   chk "Uint8ClampedArray" n (Proxy :: Proxy Uint8ClampedArray) genUint8
   chk "Uint32Array" n (Proxy :: Proxy Uint32Array) genUint32
@@ -155,564 +158,543 @@ overAll' n mn count f = do
   chk "Float32Array" n (Proxy :: Proxy Float32Array) genFloat32
   chk "Float64Array" n (Proxy :: Proxy Float64Array) genFloat64
 
-
-overAll :: forall q. Testable q
-        => Int -> Ref Int -> (forall a t. TestableArrayF a t q) -> Effect Unit
+overAll
+  :: forall q
+   . Testable q
+  => Int
+  -> Ref Int
+  -> (forall a t. TestableArrayF a t q)
+  -> Effect Unit
 overAll n count f = overAll' n 0 count f
 
-overAll1 :: forall q. Testable q
-         => Int -> Ref Int -> (forall a t. TestableArrayF a t q) -> Effect Unit
+overAll1
+  :: forall q
+   . Testable q
+  => Int
+  -> Ref Int
+  -> (forall a t. TestableArrayF a t q)
+  -> Effect Unit
 overAll1 n count f = overAll' n 1 count f
 
 subarrayBehavesLikeArraySliceTests :: Ref Int -> Effect Unit
 subarrayBehavesLikeArraySliceTests count = overAll 2 count f
   where
-    f :: forall a t. TestableArrayF a t Result
-    f (WithIndices os xs) = do
-      let s = unsafePartial $ os `Array.unsafeIndex` 0
-          e = unsafePartial $ os `Array.unsafeIndex` 1
-      axs <- TA.toArray xs
-      let sxs = TA.subArray s e xs
-      a <- TA.toArray sxs
-      pure $ Array.slice s e axs === a
+  f :: forall a t. TestableArrayF a t Result
+  f (WithIndices os xs) = do
+    let
+      s = unsafePartial $ os `Array.unsafeIndex` 0
+      e = unsafePartial $ os `Array.unsafeIndex` 1
+    axs <- TA.toArray xs
+    let sxs = TA.subArray s e xs
+    a <- TA.toArray sxs
+    pure $ Array.slice s e axs === a
 
 sliceBehavesLikeArraySliceTests :: Ref Int -> Effect Unit
 sliceBehavesLikeArraySliceTests count = overAll 2 count f
   where
-    f :: forall a t. TestableArrayF a t Result
-    f (WithIndices os xs) = do
-      let s = unsafePartial $ os `Array.unsafeIndex` 0
-          e = unsafePartial $ os `Array.unsafeIndex` 1
-      axs <- TA.toArray xs
-      sxs <- TA.slice s e xs
-      a <- TA.toArray sxs
-      pure $ Array.slice s e axs === a
+  f :: forall a t. TestableArrayF a t Result
+  f (WithIndices os xs) = do
+    let
+      s = unsafePartial $ os `Array.unsafeIndex` 0
+      e = unsafePartial $ os `Array.unsafeIndex` 1
+    axs <- TA.toArray xs
+    sxs <- TA.slice s e xs
+    a <- TA.toArray sxs
+    pure $ Array.slice s e axs === a
 
 partBehavesLikeTakeDropTests :: Ref Int -> Effect Unit
 partBehavesLikeTakeDropTests count = overAll 0 count f
   where
-    f :: forall a t. TestableArrayF a t Result
-    f (WithIndices _ xs) = do
-      let n = 2
-      axs <- TA.toArray xs
-      pxs <- TA.part (TA.buffer xs) n n :: Effect (ArrayView a)
-      aps <- TA.toArray pxs
-      pure $ Array.take n (Array.drop n axs) === aps
+  f :: forall a t. TestableArrayF a t Result
+  f (WithIndices _ xs) = do
+    let n = 2
+    axs <- TA.toArray xs
+    pxs <- TA.part (TA.buffer xs) n n :: Effect (ArrayView a)
+    aps <- TA.toArray pxs
+    pure $ Array.take n (Array.drop n axs) === aps
 
 byteLengthDivBytesPerValueTests :: Ref Int -> Effect Unit
 byteLengthDivBytesPerValueTests count = overAll 0 count byteLengthDivBytesPerValueEqLength
   where
-    byteLengthDivBytesPerValueEqLength :: forall a t. TestableArrayF a t Result
-    byteLengthDivBytesPerValueEqLength (WithIndices _ xs) =
-      let b = byteWidth (Proxy :: Proxy a)
-      in  pure $ TA.length xs === (TA.byteLength xs `div` b)
+  byteLengthDivBytesPerValueEqLength :: forall a t. TestableArrayF a t Result
+  byteLengthDivBytesPerValueEqLength (WithIndices _ xs) =
+    let
+      b = byteWidth (Proxy :: Proxy a)
+    in
+      pure $ TA.length xs === (TA.byteLength xs `div` b)
 
 fromArrayToArrayIsoTests :: Ref Int -> Effect Unit
 fromArrayToArrayIsoTests count = overAll 0 count fromArrayToArrayIso
   where
-    fromArrayToArrayIso :: forall a t. TestableArrayF a t Result
-    fromArrayToArrayIso (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      xs' <- TA.fromArray axs :: Effect (ArrayView a)
-      axs' <- TA.toArray xs'
-      pure $ axs' === axs
-
+  fromArrayToArrayIso :: forall a t. TestableArrayF a t Result
+  fromArrayToArrayIso (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    xs' <- TA.fromArray axs :: Effect (ArrayView a)
+    axs' <- TA.toArray xs'
+    pure $ axs' === axs
 
 allAreFilledTests :: Ref Int -> Effect Unit
 allAreFilledTests count = overAll 0 count allAreFilled
   where
-    allAreFilled :: forall a t. TestableArrayF a t Result
-    allAreFilled (WithIndices _ xs) = do
-      e <- TA.at xs 0
-      let x = fromMaybe zero e
-          l = TA.length xs
-      TA.fill x 0 l xs
-      b <- TA.all (_ == x) xs
-      pure (b <?> "All aren't the filled value")
-
+  allAreFilled :: forall a t. TestableArrayF a t Result
+  allAreFilled (WithIndices _ xs) = do
+    e <- TA.at xs 0
+    let
+      x = fromMaybe zero e
+      l = TA.length xs
+    TA.fill x 0 l xs
+    b <- TA.all (_ == x) xs
+    pure (b <?> "All aren't the filled value")
 
 setSingletonIsEqTests :: Ref Int -> Effect Unit
 setSingletonIsEqTests count = overAll 1 count setSingletonIsEq
   where
-    setSingletonIsEq :: forall a t. TestableArrayF a t Result
-    setSingletonIsEq (WithIndices os xs) = do
-      e <- TA.at xs 0
-      case e of
-        Nothing -> pure Success
-        Just x -> do
-          let o = unsafePartial $ Array.head os
-          _ <- TA.set xs (Just o) [x]
-          e' <- TA.at xs o
-          pure $ e' === Just x
-
+  setSingletonIsEq :: forall a t. TestableArrayF a t Result
+  setSingletonIsEq (WithIndices os xs) = do
+    e <- TA.at xs 0
+    case e of
+      Nothing -> pure Success
+      Just x -> do
+        let o = unsafePartial $ Array.head os
+        _ <- TA.set xs (Just o) [ x ]
+        e' <- TA.at xs o
+        pure $ e' === Just x
 
 -- | Should work with any arbitrary predicate, but we can't generate them
 allImpliesAnyTests :: Ref Int -> Effect Unit
 allImpliesAnyTests count = overAll 0 count allImpliesAny
   where
-    allImpliesAny :: forall a t. TestableArrayF a t Result
-    allImpliesAny (WithIndices _ xs) = do
-      let pred x = x /= zero
-      all'' <- TA.all pred xs
-      let all' = all'' <?> "All don't satisfy the predicate"
-      any'' <- TA.any pred xs
-      let any' = any'' <?> "None satisfy the predicate"
-      pure $ (TA.length xs === zero) `xor` all' `implies` any'
-
+  allImpliesAny :: forall a t. TestableArrayF a t Result
+  allImpliesAny (WithIndices _ xs) = do
+    let pred x = x /= zero
+    all'' <- TA.all pred xs
+    let all' = all'' <?> "All don't satisfy the predicate"
+    any'' <- TA.any pred xs
+    let any' = any'' <?> "None satisfy the predicate"
+    pure $ (TA.length xs === zero) `xor` all' `implies` any'
 
 -- | Should work with any arbitrary predicate, but we can't generate them
 filterImpliesAllTests :: Ref Int -> Effect Unit
 filterImpliesAllTests count = overAll 0 count filterImpliesAll
   where
-    filterImpliesAll :: forall a t. TestableArrayF a t Result
-    filterImpliesAll (WithIndices _ xs) = do
-      let pred x = x /= zero
-      ys <- TA.filter pred xs
-      all' <- TA.all pred ys
-      pure $ all' <?> "Filter doesn't imply all"
-
+  filterImpliesAll :: forall a t. TestableArrayF a t Result
+  filterImpliesAll (WithIndices _ xs) = do
+    let pred x = x /= zero
+    ys <- TA.filter pred xs
+    all' <- TA.all pred ys
+    pure $ all' <?> "Filter doesn't imply all"
 
 -- | Should work with any arbitrary predicate, but we can't generate them
 filterIsTotalTests :: Ref Int -> Effect Unit
 filterIsTotalTests count = overAll 0 count filterIsTotal
   where
-    filterIsTotal :: forall a t. TestableArrayF a t Result
-    filterIsTotal (WithIndices _ xs) = do
-      let pred x = x /= zero
-      ys <- TA.filter pred xs
-      zs <- TA.filter (not pred) ys
-      azs <- TA.toArray zs
-      pure $ azs === []
-
+  filterIsTotal :: forall a t. TestableArrayF a t Result
+  filterIsTotal (WithIndices _ xs) = do
+    let pred x = x /= zero
+    ys <- TA.filter pred xs
+    zs <- TA.filter (not pred) ys
+    azs <- TA.toArray zs
+    pure $ azs === []
 
 -- | Should work with any arbitrary predicate, but we can't generate them
 filterIsIdempotentTests :: Ref Int -> Effect Unit
 filterIsIdempotentTests count = overAll 0 count filterIsIdempotent
   where
-    filterIsIdempotent :: forall a t. TestableArrayF a t Result
-    filterIsIdempotent (WithIndices _ xs) = do
-      let pred x = x /= zero
-      ys <- TA.filter pred xs
-      zs <- TA.filter pred ys
-      azs <- TA.toArray zs
-      ays <- TA.toArray ys
-      pure $ azs === ays
-
+  filterIsIdempotent :: forall a t. TestableArrayF a t Result
+  filterIsIdempotent (WithIndices _ xs) = do
+    let pred x = x /= zero
+    ys <- TA.filter pred xs
+    zs <- TA.filter pred ys
+    azs <- TA.toArray zs
+    ays <- TA.toArray ys
+    pure $ azs === ays
 
 withIndicesHasIndexTests :: Ref Int -> Effect Unit
 withIndicesHasIndexTests count = overAll1 5 count withIndicesHasIndex
   where
-    withIndicesHasIndex :: forall a t. TestableArrayF a t Result
-    withIndicesHasIndex (WithIndices os xs) = pure $
-      Array.all (TA.hasIndex xs) os <?> "All doesn't have index of itself"
-
+  withIndicesHasIndex :: forall a t. TestableArrayF a t Result
+  withIndicesHasIndex (WithIndices os xs) = pure $
+    Array.all (TA.hasIndex xs) os <?> "All doesn't have index of itself"
 
 withIndicesElemTests :: Ref Int -> Effect Unit
 withIndicesElemTests count = overAll1 5 count withIndicesElem
   where
-    withIndicesElem :: forall a t. TestableArrayF a t Result
-    withIndicesElem (WithIndices os xs) = do
-      let fetch o = TA.at xs o
-      exs <- traverse fetch os
-      pure $ Array.all isJust exs <?> "All doesn't have an elem of itself"
-
+  withIndicesElem :: forall a t. TestableArrayF a t Result
+  withIndicesElem (WithIndices os xs) = do
+    let fetch o = TA.at xs o
+    exs <- traverse fetch os
+    pure $ Array.all isJust exs <?> "All doesn't have an elem of itself"
 
 -- | Should work with any arbitrary predicate, but we can't generate them
 anyImpliesFindTests :: Ref Int -> Effect Unit
 anyImpliesFindTests count = overAll 0 count anyImpliesFind
   where
-    anyImpliesFind :: forall a t. TestableArrayF a t Result
-    anyImpliesFind (WithIndices _ xs) = do
-      let pred x = x /= zero
-      a <- TA.any pred xs
-      let p = a <?> "All don't satisfy the predicate"
-      idx <- TA.find pred xs
-      let q = case idx of
-              Nothing -> Failed "Doesn't have a value satisfying the predicate"
-              Just z -> if pred z
-                        then Success
-                        else Failed "Found value doesn't satisfy the predicate"
-      pure $ p `implies` q
-
+  anyImpliesFind :: forall a t. TestableArrayF a t Result
+  anyImpliesFind (WithIndices _ xs) = do
+    let pred x = x /= zero
+    a <- TA.any pred xs
+    let p = a <?> "All don't satisfy the predicate"
+    idx <- TA.find pred xs
+    let
+      q = case idx of
+        Nothing -> Failed "Doesn't have a value satisfying the predicate"
+        Just z ->
+          if pred z then Success
+          else Failed "Found value doesn't satisfy the predicate"
+    pure $ p `implies` q
 
 -- | Should work with any arbitrary predicate, but we can't generate them
 findIndexImpliesAtTests :: Ref Int -> Effect Unit
 findIndexImpliesAtTests count = overAll 0 count findIndexImpliesAt
   where
-    findIndexImpliesAt :: forall a t. TestableArrayF a t Result
-    findIndexImpliesAt (WithIndices _ xs) = do
-      let pred x _ = x /= zero
-      mo <- TA.findIndex pred xs
-      case mo of
-        Nothing -> pure Success
-        Just o -> do
-          e <- TA.at xs o
-          case e of
-            Nothing -> pure $ Failed "No value at found index"
-            Just x -> pure $ pred x o <?> "Find index implies at"
-
-
+  findIndexImpliesAt :: forall a t. TestableArrayF a t Result
+  findIndexImpliesAt (WithIndices _ xs) = do
+    let pred x _ = x /= zero
+    mo <- TA.findIndex pred xs
+    case mo of
+      Nothing -> pure Success
+      Just o -> do
+        e <- TA.at xs o
+        case e of
+          Nothing -> pure $ Failed "No value at found index"
+          Just x -> pure $ pred x o <?> "Find index implies at"
 
 indexOfImpliesAtTests :: Ref Int -> Effect Unit
 indexOfImpliesAtTests count = overAll 1 count indexOfImpliesAt
   where
-    indexOfImpliesAt :: forall a t. TestableArrayF a t Result
-    indexOfImpliesAt (WithIndices _ xs) = do
-      e <- TA.at xs 0
-      case e of
-        Nothing -> pure Success
-        Just y -> do
-          idx <- TA.indexOf y Nothing xs
-          case idx of
-            Nothing -> pure $ Failed "no index of"
-            Just o -> do
-              e' <- TA.at xs o
-              pure $ e' === Just y
-
+  indexOfImpliesAt :: forall a t. TestableArrayF a t Result
+  indexOfImpliesAt (WithIndices _ xs) = do
+    e <- TA.at xs 0
+    case e of
+      Nothing -> pure Success
+      Just y -> do
+        idx <- TA.indexOf y Nothing xs
+        case idx of
+          Nothing -> pure $ Failed "no index of"
+          Just o -> do
+            e' <- TA.at xs o
+            pure $ e' === Just y
 
 lastIndexOfImpliesAtTests :: Ref Int -> Effect Unit
 lastIndexOfImpliesAtTests count = overAll 0 count lastIndexOfImpliesAt
   where
-    lastIndexOfImpliesAt :: forall a t. TestableArrayF a t Result
-    lastIndexOfImpliesAt (WithIndices _ xs) = do
-      e <- TA.at xs 0
-      case e of
-        Nothing -> pure Success
-        Just y -> do
-          idx <- TA.lastIndexOf y Nothing xs
-          case idx of
-            Nothing -> pure $ Failed "no lastIndex of"
-            Just o -> do
-              e' <- TA.at xs o
-              pure $ e' === Just y
-
+  lastIndexOfImpliesAt :: forall a t. TestableArrayF a t Result
+  lastIndexOfImpliesAt (WithIndices _ xs) = do
+    e <- TA.at xs 0
+    case e of
+      Nothing -> pure Success
+      Just y -> do
+        idx <- TA.lastIndexOf y Nothing xs
+        case idx of
+          Nothing -> pure $ Failed "no lastIndex of"
+          Just o -> do
+            e' <- TA.at xs o
+            pure $ e' === Just y
 
 foldrConsIsToArrayTests :: Ref Int -> Effect Unit
 foldrConsIsToArrayTests count = overAll 0 count foldrConsIsToArray
   where
-    foldrConsIsToArray :: forall a t. TestableArrayF a t Result
-    foldrConsIsToArray (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      rxs <- TA.foldr Array.cons [] xs
-      pure $ rxs === axs
-
+  foldrConsIsToArray :: forall a t. TestableArrayF a t Result
+  foldrConsIsToArray (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    rxs <- TA.foldr Array.cons [] xs
+    pure $ rxs === axs
 
 foldlSnocIsToArrayTests :: Ref Int -> Effect Unit
 foldlSnocIsToArrayTests count = overAll 0 count foldlSnocIsToArray
   where
-    foldlSnocIsToArray :: forall a t. TestableArrayF a t Result
-    foldlSnocIsToArray (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      rxs <- TA.foldl Array.snoc [] xs
-      pure $ rxs === axs
-
+  foldlSnocIsToArray :: forall a t. TestableArrayF a t Result
+  foldlSnocIsToArray (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    rxs <- TA.foldl Array.snoc [] xs
+    pure $ rxs === axs
 
 mapIdentityIsIdentityTests :: Ref Int -> Effect Unit
 mapIdentityIsIdentityTests count = overAll 0 count mapIdentityIsIdentity
   where
-    mapIdentityIsIdentity :: forall a t. TestableArrayF a t Result
-    mapIdentityIsIdentity (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      mxs <- TA.toArray (TA.map identity xs)
-      pure $ axs === mxs
-
+  mapIdentityIsIdentity :: forall a t. TestableArrayF a t Result
+  mapIdentityIsIdentity (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    mxs <- TA.toArray (TA.map identity xs)
+    pure $ axs === mxs
 
 traverseSnocIsToArrayTests :: Ref Int -> Effect Unit
 traverseSnocIsToArrayTests count = overAll 0 count traverseSnocIsToArray
   where
-    traverseSnocIsToArray :: forall a t. TestableArrayF a t Result
-    traverseSnocIsToArray (WithIndices _ xs) = do
-      ref <- Ref.new []
-      TA.traverse_ (\x -> void (Ref.modify (\xs' -> Array.snoc xs' x) ref)) xs
-      ys <- Ref.read ref
-      axs <- TA.toArray xs
-      pure $ axs === ys
-
+  traverseSnocIsToArray :: forall a t. TestableArrayF a t Result
+  traverseSnocIsToArray (WithIndices _ xs) = do
+    ref <- Ref.new []
+    TA.traverse_ (\x -> void (Ref.modify (\xs' -> Array.snoc xs' x) ref)) xs
+    ys <- Ref.read ref
+    axs <- TA.toArray xs
+    pure $ axs === ys
 
 doubleReverseIsIdentityTests :: Ref Int -> Effect Unit
 doubleReverseIsIdentityTests count = overAll 0 count doubleReverseIsIdentity
   where
-    doubleReverseIsIdentity :: forall a t. TestableArrayF a t Result
-    doubleReverseIsIdentity (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      TA.reverse xs
-      TA.reverse xs
-      axs' <- TA.toArray xs
-      pure $ axs === axs'
-
+  doubleReverseIsIdentity :: forall a t. TestableArrayF a t Result
+  doubleReverseIsIdentity (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    TA.reverse xs
+    TA.reverse xs
+    axs' <- TA.toArray xs
+    pure $ axs === axs'
 
 reverseIsArrayReverseTests :: Ref Int -> Effect Unit
 reverseIsArrayReverseTests count = overAll 0 count reverseIsArrayReverse
   where
-    reverseIsArrayReverse :: forall a t. TestableArrayF a t Result
-    reverseIsArrayReverse (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      TA.reverse xs
-      rxs <- TA.toArray xs
-      pure $ Array.reverse axs === rxs
-
+  reverseIsArrayReverse :: forall a t. TestableArrayF a t Result
+  reverseIsArrayReverse (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    TA.reverse xs
+    rxs <- TA.toArray xs
+    pure $ Array.reverse axs === rxs
 
 sortIsIdempotentTests :: Ref Int -> Effect Unit
 sortIsIdempotentTests count = overAll 0 count sortIsIdempotent
   where
-    sortIsIdempotent :: forall a t. TestableArrayF a t Result
-    sortIsIdempotent (WithIndices _ xs) = do
-      TA.sort xs
-      ys <- TA.toArray xs
-      TA.sort xs
-      zs <- TA.toArray xs
-      pure $ zs === ys
-
+  sortIsIdempotent :: forall a t. TestableArrayF a t Result
+  sortIsIdempotent (WithIndices _ xs) = do
+    TA.sort xs
+    ys <- TA.toArray xs
+    TA.sort xs
+    zs <- TA.toArray xs
+    pure $ zs === ys
 
 sortIsArraySortTests :: Ref Int -> Effect Unit
 sortIsArraySortTests count = overAll 0 count sortIsArraySort
   where
-    sortIsArraySort :: forall a t. TestableArrayF a t Result
-    sortIsArraySort (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      let ys = Array.sort axs
-      TA.sort xs
-      sxs <- TA.toArray xs
-      pure $ sxs === ys
-
+  sortIsArraySort :: forall a t. TestableArrayF a t Result
+  sortIsArraySort (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    let ys = Array.sort axs
+    TA.sort xs
+    sxs <- TA.toArray xs
+    pure $ sxs === ys
 
 toStringIsJoinWithCommaTests :: Ref Int -> Effect Unit
 toStringIsJoinWithCommaTests count = overAll 0 count toStringIsJoinWithComma
   where
-    toStringIsJoinWithComma :: forall a t. TestableArrayF a t Result
-    toStringIsJoinWithComma (WithIndices _ xs) = do
-      s1 <- TA.join "," xs
-      s2 <- TA.toString xs
-      pure $ s1 === s2
-
+  toStringIsJoinWithComma :: forall a t. TestableArrayF a t Result
+  toStringIsJoinWithComma (WithIndices _ xs) = do
+    s1 <- TA.join "," xs
+    s2 <- TA.toString xs
+    pure $ s1 === s2
 
 setTypedOfSubArrayIsIdentityTests :: Ref Int -> Effect Unit
 setTypedOfSubArrayIsIdentityTests count = overAll 0 count setTypedOfSubArrayIsIdentity
   where
-    setTypedOfSubArrayIsIdentity :: forall a t. TestableArrayF a t Result
-    setTypedOfSubArrayIsIdentity (WithIndices _ xs) = do
-      ys <- TA.toArray xs
-      let l = TA.length xs
-          zsSub = TA.subArray 0 l xs
-      _ <- TA.setTyped xs Nothing zsSub
-      zs <- TA.toArray xs
-      pure $ zs === ys
-
+  setTypedOfSubArrayIsIdentity :: forall a t. TestableArrayF a t Result
+  setTypedOfSubArrayIsIdentity (WithIndices _ xs) = do
+    ys <- TA.toArray xs
+    let
+      l = TA.length xs
+      zsSub = TA.subArray 0 l xs
+    _ <- TA.setTyped xs Nothing zsSub
+    zs <- TA.toArray xs
+    pure $ zs === ys
 
 modifyingOriginalMutatesSubArrayTests :: Ref Int -> Effect Unit
 modifyingOriginalMutatesSubArrayTests count = overAll 0 count modifyingOriginalMutatesSubArray
   where
-    modifyingOriginalMutatesSubArray :: forall a t. TestableArrayF a t Result
-    modifyingOriginalMutatesSubArray (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      if Array.all (eq zero) axs
-        then pure Success
-        else do
-        let l = TA.length xs
-            zsSub = TA.subArray 0 l xs
-        zs <- TA.toArray zsSub
-        TA.fill zero 0 l xs
-        ys <-  TA.toArray zsSub
-        pure $ zs /== ys
-
+  modifyingOriginalMutatesSubArray :: forall a t. TestableArrayF a t Result
+  modifyingOriginalMutatesSubArray (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    if Array.all (eq zero) axs then pure Success
+    else do
+      let
+        l = TA.length xs
+        zsSub = TA.subArray 0 l xs
+      zs <- TA.toArray zsSub
+      TA.fill zero 0 l xs
+      ys <- TA.toArray zsSub
+      pure $ zs /== ys
 
 modifyingSubArrayMutatesOriginalTests :: Ref Int -> Effect Unit
 modifyingSubArrayMutatesOriginalTests count = overAll 0 count modifyingOriginalMutatesSubArray
   where
-    modifyingOriginalMutatesSubArray :: forall a t. TestableArrayF a t Result
-    modifyingOriginalMutatesSubArray (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      if Array.all (eq zero) axs
-        then pure Success
-        else do
-        let l = TA.length xs
-            zsSub = TA.subArray 0 l xs
-        zs <- TA.toArray xs
-        TA.fill zero 0 l zsSub
-        ys <- TA.toArray xs
-        pure $ zs /== ys
-
+  modifyingOriginalMutatesSubArray :: forall a t. TestableArrayF a t Result
+  modifyingOriginalMutatesSubArray (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    if Array.all (eq zero) axs then pure Success
+    else do
+      let
+        l = TA.length xs
+        zsSub = TA.subArray 0 l xs
+      zs <- TA.toArray xs
+      TA.fill zero 0 l zsSub
+      ys <- TA.toArray xs
+      pure $ zs /== ys
 
 modifyingOriginalMutatesSubArrayZeroTests :: Ref Int -> Effect Unit
 modifyingOriginalMutatesSubArrayZeroTests count = overAll 0 count modifyingOriginalMutatesSubArrayZero
   where
-    modifyingOriginalMutatesSubArrayZero :: forall a t. TestableArrayF a t Result
-    modifyingOriginalMutatesSubArrayZero (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      if Array.all (eq zero) axs
-        then pure Success
-        else do
-        let l = TA.length xs
-            zsSub = TA.subArray 0 l xs
-        zs <- TA.toArray zsSub
-        TA.fill zero 0 l xs
-        ys <- TA.toArray zsSub
-        pure $ zs /== ys
-
+  modifyingOriginalMutatesSubArrayZero :: forall a t. TestableArrayF a t Result
+  modifyingOriginalMutatesSubArrayZero (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    if Array.all (eq zero) axs then pure Success
+    else do
+      let
+        l = TA.length xs
+        zsSub = TA.subArray 0 l xs
+      zs <- TA.toArray zsSub
+      TA.fill zero 0 l xs
+      ys <- TA.toArray zsSub
+      pure $ zs /== ys
 
 modifyingSubArrayMutatesOriginalZeroTests :: Ref Int -> Effect Unit
 modifyingSubArrayMutatesOriginalZeroTests count = overAll 0 count modifyingSubArrayMutatesOriginalZero
   where
-    modifyingSubArrayMutatesOriginalZero :: forall a t. TestableArrayF a t Result
-    modifyingSubArrayMutatesOriginalZero (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      if Array.all (eq zero) axs
-        then pure Success
-        else do
-        let l = TA.length xs
-            zsSub = TA.subArray 0 l xs
-        zs <- TA.toArray xs
-        TA.fill zero 0 l zsSub
-        ys <- TA.toArray xs
-        pure $ zs /== ys
-
+  modifyingSubArrayMutatesOriginalZero :: forall a t. TestableArrayF a t Result
+  modifyingSubArrayMutatesOriginalZero (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    if Array.all (eq zero) axs then pure Success
+    else do
+      let
+        l = TA.length xs
+        zsSub = TA.subArray 0 l xs
+      zs <- TA.toArray xs
+      TA.fill zero 0 l zsSub
+      ys <- TA.toArray xs
+      pure $ zs /== ys
 
 modifyingOriginalMutatesSubArrayAllTests :: Ref Int -> Effect Unit
 modifyingOriginalMutatesSubArrayAllTests count = overAll 0 count modifyingOriginalMutatesSubArrayAll
   where
-    modifyingOriginalMutatesSubArrayAll :: forall a t. TestableArrayF a t Result
-    modifyingOriginalMutatesSubArrayAll (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      if Array.all (eq zero) axs
-        then pure Success
-        else do
-        let l = TA.length xs
-            zsSub = TA.subArray 0 l xs
-        zs <- TA.toArray zsSub
-        TA.fill zero 0 l xs
-        ys <- TA.toArray zsSub
-        pure $ zs /== ys
-
+  modifyingOriginalMutatesSubArrayAll :: forall a t. TestableArrayF a t Result
+  modifyingOriginalMutatesSubArrayAll (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    if Array.all (eq zero) axs then pure Success
+    else do
+      let
+        l = TA.length xs
+        zsSub = TA.subArray 0 l xs
+      zs <- TA.toArray zsSub
+      TA.fill zero 0 l xs
+      ys <- TA.toArray zsSub
+      pure $ zs /== ys
 
 modifyingSubArrayMutatesOriginalAllTests :: Ref Int -> Effect Unit
 modifyingSubArrayMutatesOriginalAllTests count = overAll 0 count modifyingSubArrayMutatesOriginalAll
   where
-    modifyingSubArrayMutatesOriginalAll :: forall a t. TestableArrayF a t Result
-    modifyingSubArrayMutatesOriginalAll (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      if Array.all (eq zero) axs
-        then pure Success
-        else do
-        let l = TA.length xs
-            zsSub = TA.subArray 0 l xs
-        zs <- TA.toArray xs
-        TA.fill zero 0 l zsSub
-        ys <- TA.toArray xs
-        pure $ zs /== ys
-
+  modifyingSubArrayMutatesOriginalAll :: forall a t. TestableArrayF a t Result
+  modifyingSubArrayMutatesOriginalAll (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    if Array.all (eq zero) axs then pure Success
+    else do
+      let
+        l = TA.length xs
+        zsSub = TA.subArray 0 l xs
+      zs <- TA.toArray xs
+      TA.fill zero 0 l zsSub
+      ys <- TA.toArray xs
+      pure $ zs /== ys
 
 modifyingOriginalMutatesSubArrayPartTests :: Ref Int -> Effect Unit
 modifyingOriginalMutatesSubArrayPartTests count = overAll 1 count modifyingOriginalMutatesSubArrayPart
   where
-    modifyingOriginalMutatesSubArrayPart :: forall a t. TestableArrayF a t Result
-    modifyingOriginalMutatesSubArrayPart (WithIndices os xs) = do
-      let o = unsafePartial $ Array.head os
-          l = TA.length xs
-          zsSub = TA.subArray 0 l xs
-      zs <- TA.toArray zsSub
-      if o == 0 || Array.all (eq zero) zs
-        then pure Success
-        else do
-        TA.fill zero 0 l xs
-        ys <- TA.toArray zsSub
-        pure $ zs /== ys
-
+  modifyingOriginalMutatesSubArrayPart :: forall a t. TestableArrayF a t Result
+  modifyingOriginalMutatesSubArrayPart (WithIndices os xs) = do
+    let
+      o = unsafePartial $ Array.head os
+      l = TA.length xs
+      zsSub = TA.subArray 0 l xs
+    zs <- TA.toArray zsSub
+    if o == 0 || Array.all (eq zero) zs then pure Success
+    else do
+      TA.fill zero 0 l xs
+      ys <- TA.toArray zsSub
+      pure $ zs /== ys
 
 modifyingOriginalDoesntMutateSliceTests :: Ref Int -> Effect Unit
 modifyingOriginalDoesntMutateSliceTests count = overAll 0 count modifyingOriginalDoesntMutateSlice
   where
-    modifyingOriginalDoesntMutateSlice :: forall a t. TestableArrayF a t Result
-    modifyingOriginalDoesntMutateSlice (WithIndices _ xs) = do
-      axs <- TA.toArray xs
-      if Array.all (eq zero) axs
-        then pure Success
-        else do
-        let l = TA.length xs
-        zsSub <- TA.slice 0 l xs
-        zs <- TA.toArray zsSub
-        TA.fill zero 0 l xs
-        ys <- TA.toArray zsSub
-        pure $ zs === ys
-
+  modifyingOriginalDoesntMutateSlice :: forall a t. TestableArrayF a t Result
+  modifyingOriginalDoesntMutateSlice (WithIndices _ xs) = do
+    axs <- TA.toArray xs
+    if Array.all (eq zero) axs then pure Success
+    else do
+      let l = TA.length xs
+      zsSub <- TA.slice 0 l xs
+      zs <- TA.toArray zsSub
+      TA.fill zero 0 l xs
+      ys <- TA.toArray zsSub
+      pure $ zs === ys
 
 modifyingOriginalDoesntMutateSlicePartTests :: Ref Int -> Effect Unit
 modifyingOriginalDoesntMutateSlicePartTests count = overAll 1 count modifyingOriginalDoesntMutateSlicePart
   where
-    modifyingOriginalDoesntMutateSlicePart :: forall a t. TestableArrayF a t Result
-    modifyingOriginalDoesntMutateSlicePart (WithIndices os xs) = do
-      let l = TA.length xs
-      axs <- TA.toArray =<< TA.slice 0 l xs
-      let o = unsafePartial $ Array.head os
-      e <- TA.at xs o
-      if Array.all (eq zero) axs || e == Just zero
-        then pure Success
-        else do
-        zsSub <- TA.slice o l xs
-        zs <- TA.toArray zsSub
-        TA.fill zero 0 l xs
-        ys <- TA.toArray zsSub
-        pure $ zs === ys
-
+  modifyingOriginalDoesntMutateSlicePart :: forall a t. TestableArrayF a t Result
+  modifyingOriginalDoesntMutateSlicePart (WithIndices os xs) = do
+    let l = TA.length xs
+    axs <- TA.toArray =<< TA.slice 0 l xs
+    let o = unsafePartial $ Array.head os
+    e <- TA.at xs o
+    if Array.all (eq zero) axs || e == Just zero then pure Success
+    else do
+      zsSub <- TA.slice o l xs
+      zs <- TA.toArray zsSub
+      TA.fill zero 0 l xs
+      ys <- TA.toArray zsSub
+      pure $ zs === ys
 
 modifyingOriginalDoesntMutateSlicePart2Tests :: Ref Int -> Effect Unit
 modifyingOriginalDoesntMutateSlicePart2Tests count = overAll 1 count modifyingOriginalDoesntMutateSlicePart2
   where
-    modifyingOriginalDoesntMutateSlicePart2 :: forall a t. TestableArrayF a t Result
-    modifyingOriginalDoesntMutateSlicePart2 (WithIndices os xs) = do
-      let o = unsafePartial $ Array.head os
-          l = TA.length xs
-      axs <- TA.toArray =<< TA.slice o l xs
-      e <- TA.at xs o
-      if Array.all (eq zero) axs || e == Just zero
-        then pure Success
-        else do
-        zsSub <- TA.slice o l xs
-        zs <- TA.toArray zsSub
-        TA.fill zero 0 l xs
-        ys <- TA.toArray zsSub
-        pure $ zs === ys
-
+  modifyingOriginalDoesntMutateSlicePart2 :: forall a t. TestableArrayF a t Result
+  modifyingOriginalDoesntMutateSlicePart2 (WithIndices os xs) = do
+    let
+      o = unsafePartial $ Array.head os
+      l = TA.length xs
+    axs <- TA.toArray =<< TA.slice o l xs
+    e <- TA.at xs o
+    if Array.all (eq zero) axs || e == Just zero then pure Success
+    else do
+      zsSub <- TA.slice o l xs
+      zs <- TA.toArray zsSub
+      TA.fill zero 0 l xs
+      ys <- TA.toArray zsSub
+      pure $ zs === ys
 
 copyWithinSelfIsIdentityTests :: Ref Int -> Effect Unit
 copyWithinSelfIsIdentityTests count = overAll 0 count copyWithinSelfIsIdentity
   where
-    copyWithinSelfIsIdentity :: forall a t. TestableArrayF a t Result
-    copyWithinSelfIsIdentity (WithIndices _ xs) = do
-      ys <- TA.toArray xs
-      TA.copyWithin xs 0 0 (Just (TA.length xs))
-      zs <- TA.toArray xs
-      pure $ zs === ys
-
+  copyWithinSelfIsIdentity :: forall a t. TestableArrayF a t Result
+  copyWithinSelfIsIdentity (WithIndices _ xs) = do
+    ys <- TA.toArray xs
+    TA.copyWithin xs 0 0 (Just (TA.length xs))
+    zs <- TA.toArray xs
+    pure $ zs === ys
 
 copyWithinIsSliceTests :: Ref Int -> Effect Unit
 copyWithinIsSliceTests count = overAll 1 count copyWithinIsSlice
   where
-    copyWithinIsSlice :: forall a t. TestableArrayF a t Result
-    copyWithinIsSlice (WithIndices os xs) = do
-      let o = unsafePartial $ Array.head os
-          l = TA.length xs
-      ys <- TA.toArray =<< TA.slice o l xs
-      TA.copyWithin xs 0 o Nothing
-      axs <- TA.toArray xs
-      zs <- pure $ Array.drop (Array.length ys) axs
-      pure $ axs === ys <> zs
-
+  copyWithinIsSlice :: forall a t. TestableArrayF a t Result
+  copyWithinIsSlice (WithIndices os xs) = do
+    let
+      o = unsafePartial $ Array.head os
+      l = TA.length xs
+    ys <- TA.toArray =<< TA.slice o l xs
+    TA.copyWithin xs 0 o Nothing
+    axs <- TA.toArray xs
+    zs <- pure $ Array.drop (Array.length ys) axs
+    pure $ axs === ys <> zs
 
 copyWithinViaSetTypedTests :: Ref Int -> Effect Unit
 copyWithinViaSetTypedTests count = overAll 1 count copyWithinViaSetTyped
   where
-    copyWithinViaSetTyped :: forall a t. TestableArrayF a t Result
-    copyWithinViaSetTyped (WithIndices os xs) = do
-      let o = unsafePartial $ Array.head os
-      txs <- TA.toArray xs
-      xs' <- TA.fromArray txs :: Effect (ArrayView a)
-      let l = TA.length xs'
-      ys <- TA.slice o l xs'
-      _ <- TA.setTyped xs' Nothing ys
-      TA.copyWithin xs 0 o Nothing
-      axs <- TA.toArray xs
-      axs' <- TA.toArray xs'
-      pure $ axs === axs'
+  copyWithinViaSetTyped :: forall a t. TestableArrayF a t Result
+  copyWithinViaSetTyped (WithIndices os xs) = do
+    let o = unsafePartial $ Array.head os
+    txs <- TA.toArray xs
+    xs' <- TA.fromArray txs :: Effect (ArrayView a)
+    let l = TA.length xs'
+    ys <- TA.slice o l xs'
+    _ <- TA.setTyped xs' Nothing ys
+    TA.copyWithin xs 0 o Nothing
+    axs <- TA.toArray xs
+    axs' <- TA.toArray xs'
+    pure $ axs === axs'
 
 -- | Uses the second failure message as the result failure message
 -- | https://github.com/athanclark/purescript-quickcheck-combinators/blob/293e5af07ae47b61d4eae5defef4c0f472bfa9ca/src/Test/QuickCheck/Combinators.purs#L62
@@ -729,9 +711,12 @@ xor :: Result -> Result -> Result
 xor = xor' ", xor " "XOR"
   where
   -- Combine two results with "Exclusive Or" logic, and with a failure message separator and failure message if they are both `Success`
-  xor' :: String -- ^ Separator
-      -> String -- ^ Success failure message
-      -> Result -> Result -> Result
+  xor'
+    :: String -- ^ Separator
+    -> String -- ^ Success failure message
+    -> Result
+    -> Result
+    -> Result
   xor' m s x y = case Tuple x y of
     Tuple (Failed x') (Failed y') -> Failed (x' <> m <> y')
     Tuple Success Success -> Failed s

--- a/test/Properties/TypedArray.purs
+++ b/test/Properties/TypedArray.purs
@@ -217,11 +217,9 @@ byteLengthDivBytesPerValueTests :: Ref Int -> Effect Unit
 byteLengthDivBytesPerValueTests count = overAll 0 count byteLengthDivBytesPerValueEqLength
   where
   byteLengthDivBytesPerValueEqLength :: forall a t. TestableArrayF a t Result
-  byteLengthDivBytesPerValueEqLength (WithIndices _ xs) =
-    let
-      b = byteWidth (Proxy :: Proxy a)
-    in
-      pure $ TA.length xs === (TA.byteLength xs `div` b)
+  byteLengthDivBytesPerValueEqLength (WithIndices _ xs) = do
+    let b = byteWidth (Proxy :: Proxy a)
+    pure $ TA.length xs === (TA.byteLength xs `div` b)
 
 fromArrayToArrayIsoTests :: Ref Int -> Effect Unit
 fromArrayToArrayIsoTests count = overAll 0 count fromArrayToArrayIso


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
